### PR TITLE
DSND-2305: Allow health checks REST calls to bypass auth checks

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,7 @@
       <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring.boot.version}</version>
         <executions>
           <execution>
             <goals>

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/config/WebConfig.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/config/WebConfig.java
@@ -12,6 +12,8 @@ class WebConfig implements WebMvcConfigurer {
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new RequestLoggingInterceptor());
-        registry.addInterceptor(new AuthenticationInterceptor());
+        registry.addInterceptor(new AuthenticationInterceptor())
+                .addPathPatterns("/**")
+                .excludePathPatterns("/healthcheck");
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 management.endpoints.enabled-by-default=false
-management.endpoints.web.base-path=/filing-history-data-api
+management.endpoints.web.base-path=/
 management.endpoints.web.path-mapping.health=healthcheck
 management.endpoint.health.show-details=never
 management.endpoint.health.enabled=true

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/interceptor/AuthenticationInterceptorITest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/interceptor/AuthenticationInterceptorITest.java
@@ -1,6 +1,5 @@
-package uk.gov.companieshouse.filinghistory.api;
+package uk.gov.companieshouse.filinghistory.api.interceptor;
 
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -11,22 +10,13 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.web.context.WebApplicationContext;
 
+@SpringBootTest
 @AutoConfigureMockMvc
-@SpringBootTest(classes = FilingHistoryApplication.class, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-class FilingHistoryApplicationIT {
+class AuthenticationInterceptorITest {
 
     @Autowired
     private MockMvc mockMvc;
-
-    @Autowired
-    private WebApplicationContext context;
-
-    @Test
-    void shouldLoadApplicationContext() {
-        assertNotNull(context);
-    }
 
     @Test
     void shouldReturn200FromGetHealthEndpoint() throws Exception {
@@ -34,5 +24,12 @@ class FilingHistoryApplicationIT {
                 .andDo(print())
                 .andExpect(status().isOk())
                 .andExpect(content().string("{\"status\":\"UP\"}"));
+    }
+
+    @Test
+    void shouldReturn401FromEndpointWithoutAuth() throws Exception {
+        this.mockMvc.perform(get("/test"))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
     }
 }


### PR DESCRIPTION
## Describe the changes

Updates make sure the health check in ECS will work when called without auth headers
* Added path rules to the `AuthenticationInterceptor` configuration in `WebConfig`
* Fixed the Spring Actuator base path
* Updated integration tests to for health checks not being blocked

### Related Jira tickets

[DSND-2305](https://companieshouse.atlassian.net/browse/DSND-2305)

## Developer check list

### General

- [X] Is the PR as small as it can be?
- [X] Has the Jira ticket been updated with any relevant comments?
- [X] Is the `README` up to date?
- [X] Has the `POM` been updated for the latest versions of dependencies?
- [X] Has the code been double-checked against `main`?
- [X] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [X] Do the code changes have unit and integration tests with code coverage > 80%?
- [N/A] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [N/A ] Have mandatory manual test cases been run?
- [N/A] Are extra Karate tests required?
- [X] Are all the test data resources up to date?

### Release preparation

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

Not for testing as yet

[DSND-2305]: https://companieshouse.atlassian.net/browse/DSND-2305?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ