### PR TITLE
DSND-2170: Add ERIC container config to allow ERIC proxy

### DIFF
--- a/terraform/groups/ecs-service/locals.tf
+++ b/terraform/groups/ecs-service/locals.tf
@@ -5,6 +5,7 @@ locals {
   global_prefix               = "global-${var.environment}"
   service_name                = "filing-history-data-api"
   container_port              = "8080"
+  eric_port                   = "10000"
   docker_repo                 = "filing-history-data-api"
   kms_alias                   = "alias/${var.aws_profile}/environment-services-kms"
   lb_listener_rule_priority   = 41
@@ -66,4 +67,11 @@ locals {
     { name : "PORT", value : local.container_port },
     { name : "LOGLEVEL", value : var.log_level }
   ])
+
+  # get eric secrets from global secrets map
+  eric_secrets = [
+    { "name": "API_KEY", "valueFrom": local.global_secrets_arn_map.eric_api_key },
+    { "name": "AES256_KEY", "valueFrom": local.global_secrets_arn_map.eric_aes256_key }
+  ]
+  eric_environment_filename = "eric.env"
 }

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -19,7 +19,7 @@ terraform {
 }
 
 module "ecs-service" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.235"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/ecs-service?ref=1.0.243"
 
 
   # Environmental configuration
@@ -71,10 +71,19 @@ module "ecs-service" {
   task_secrets                = local.task_secrets
   app_environment_filename    = local.app_environment_filename
   use_set_environment_files   = local.use_set_environment_files
+
+  # eric options for eric running API module
+  use_eric_reverse_proxy    = true
+  eric_version              = var.eric_version
+  eric_cpus                 = var.eric_cpus
+  eric_memory               = var.eric_memory
+  eric_port                 = local.eric_port
+  eric_environment_filename = local.eric_environment_filename
+  eric_secrets              = local.eric_secrets
 }
 
 module "secrets" {
-  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.235"
+  source = "git@github.com:companieshouse/terraform-modules//aws/ecs/secrets?ref=1.0.243"
 
   name_prefix = "${local.service_name}-${var.environment}"
   environment = var.environment

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -42,6 +42,16 @@ variable "required_memory" {
   description = "The required memory for this service"
   default = 512 # defaulted low for node service in dev environments, override for production
 }
+variable "eric_cpus" {
+  type = number
+  description = "The required cpu resource for eric. 1024 here is 1 vCPU"
+  default = 256
+}
+variable "eric_memory" {
+  type = number
+  description = "The required memory for eric"
+  default = 512
+}
 
 variable "max_task_count" {
   type        = number
@@ -117,4 +127,9 @@ variable "log_level" {
 variable "filing_history_data_api_version" {
   type        = string
   description = "The version of the filing-history-data-api container to run."
+}
+
+variable "eric_version" {
+  type        = string
+  description = "The version of the eric container to run."
 }


### PR DESCRIPTION
* Changes to the terraform config to allow the ERIC container module to be used.
* Otherwise requests do not go through ERIC on ECS and so arrive to their location without any auth headers.
