### PR TITLE
DSND-2318: Temporarily set lb to private for live deployment

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -31,20 +31,20 @@ module "ecs-service" {
   task_execution_role_arn = data.aws_iam_role.ecs_cluster_iam_role.arn
 
   # Load balancer configuration
-  lb_listener_arn                 = data.aws_lb_listener.secondary_lb_listener.arn
+  lb_listener_arn                 = data.aws_lb_listener.service_lb_listener.arn
   lb_listener_rule_priority       = local.lb_listener_rule_priority
   lb_listener_paths               = local.lb_listener_paths
-#  multilb_setup                   = true
-#  multilb_listeners               = {
-#    "priva-api-lb": {
-#          listener_arn            = data.aws_lb_listener.secondary_lb_listener.arn,
-#          load_balancer_arn       = data.aws_lb.secondary_lb.arn
-#      }
+  multilb_setup                   = true
+  multilb_listeners               = {
+    "priva-api-lb": {
+          listener_arn            = data.aws_lb_listener.secondary_lb_listener.arn,
+          load_balancer_arn       = data.aws_lb.secondary_lb.arn
+      }
 #    "publ-api-lb": {
 #      load_balancer_arn           = data.aws_lb.service_lb.arn
 #      listener_arn                = data.aws_lb_listener.service_lb_listener.arn
 #    }
-#  }
+  }
 
   # ECS Task container health check
   use_task_container_healthcheck = true

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -31,20 +31,20 @@ module "ecs-service" {
   task_execution_role_arn = data.aws_iam_role.ecs_cluster_iam_role.arn
 
   # Load balancer configuration
-  lb_listener_arn                 = data.aws_lb_listener.service_lb_listener.arn
+  lb_listener_arn                 = data.aws_lb_listener.secondary_lb_listener.arn
   lb_listener_rule_priority       = local.lb_listener_rule_priority
   lb_listener_paths               = local.lb_listener_paths
-  multilb_setup                   = true
-  multilb_listeners               = {
-    "priva-api-lb": {
-          listener_arn            = data.aws_lb_listener.secondary_lb_listener.arn,
-          load_balancer_arn       = data.aws_lb.secondary_lb.arn
-      }
-    "publ-api-lb": {
-      load_balancer_arn           = data.aws_lb.service_lb.arn
-      listener_arn                = data.aws_lb_listener.service_lb_listener.arn
-    }      
-  }
+#  multilb_setup                   = true
+#  multilb_listeners               = {
+#    "priva-api-lb": {
+#          listener_arn            = data.aws_lb_listener.secondary_lb_listener.arn,
+#          load_balancer_arn       = data.aws_lb.secondary_lb.arn
+#      }
+#    "publ-api-lb": {
+#      load_balancer_arn           = data.aws_lb.service_lb.arn
+#      listener_arn                = data.aws_lb_listener.service_lb_listener.arn
+#    }
+#  }
 
   # ECS Task container health check
   use_task_container_healthcheck = true


### PR DESCRIPTION
## Describe the changes
* Until the full filing history delta is ready to go live the data API will sit only on the private LB so its not accessible externally.

### Related Jira tickets

[DSND-2318](https://companieshouse.atlassian.net/browse/DSND-2318)

## Developer check list

### General

- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._


[DSND-2318]: https://companieshouse.atlassian.net/browse/DSND-2318?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ