### PR TITLE
DSND-2599: Fix bug where action date wasn't on AssociatedFiling document object

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/get/AssociatedFilingsGetResponseMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/get/AssociatedFilingsGetResponseMapper.java
@@ -23,6 +23,7 @@ public class AssociatedFilingsGetResponseMapper {
                         .stream()
                         .map(associatedFiling ->
                                 new AssociatedFiling()
+                                        .actionDate(instantToString(associatedFiling.getActionDate()))
                                         .originalDescription(associatedFiling.getOriginalDescription())
                                         .category(associatedFiling.getCategory())
                                         .type(associatedFiling.getType())

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/AssociatedFilingChildMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/AssociatedFilingChildMapper.java
@@ -25,6 +25,7 @@ public class AssociatedFilingChildMapper implements ChildMapper<FilingHistoryAss
                 request.getExternalData().getAssociatedFilings().getFirst();
 
         return existingAssociatedFiling
+                .actionDate(stringToInstant(requestAssociatedFilings.getActionDate()))
                 .entityId(internalData.getEntityId())
                 .originalDescription(requestAssociatedFilings.getOriginalDescription())
                 .deltaAt(internalData.getDeltaAt())

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/model/mongo/FilingHistoryAssociatedFiling.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/model/mongo/FilingHistoryAssociatedFiling.java
@@ -17,6 +17,9 @@ public class FilingHistoryAssociatedFiling extends FilingHistoryChild {
     @Field("original_description")
     @JsonProperty("original_description")
     private String originalDescription;
+    @Field("action_date")
+    @JsonProperty("action_date")
+    private Instant actionDate;
 
     @Override
     public FilingHistoryAssociatedFiling entityId(String entityId) {
@@ -84,6 +87,15 @@ public class FilingHistoryAssociatedFiling extends FilingHistoryChild {
         return this;
     }
 
+    public Instant getActionDate() {
+        return actionDate;
+    }
+
+    public FilingHistoryAssociatedFiling actionDate(Instant actionDate) {
+        this.actionDate = actionDate;
+        return this;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -96,16 +108,19 @@ public class FilingHistoryAssociatedFiling extends FilingHistoryChild {
             return false;
         }
         FilingHistoryAssociatedFiling that = (FilingHistoryAssociatedFiling) o;
-        return Objects.equals(category, that.category) && Objects.equals(description, that.description)
-                && Objects.equals(type, that.type) && Objects.equals(date, that.date)
-                && Objects.equals(descriptionValues, that.descriptionValues) && Objects.equals(
-                originalDescription, that.originalDescription);
+        return Objects.equals(category, that.category)
+                && Objects.equals(description, that.description)
+                && Objects.equals(type, that.type)
+                && Objects.equals(date, that.date)
+                && Objects.equals(descriptionValues, that.descriptionValues)
+                && Objects.equals(originalDescription, that.originalDescription)
+                && Objects.equals(actionDate, that.actionDate);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), category, description, type, date, descriptionValues,
-                originalDescription);
+        return Objects.hash(
+                super.hashCode(), category, description, type, date, descriptionValues, originalDescription, actionDate);
     }
 
     @Override
@@ -117,6 +132,7 @@ public class FilingHistoryAssociatedFiling extends FilingHistoryChild {
                 ", date=" + date +
                 ", descriptionValues=" + descriptionValues +
                 ", originalDescription='" + originalDescription + '\'' +
-                "} " + super.toString();
+                ", actionDate='" + actionDate + '\'' +
+                '}' + super.toString();
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AssociatedFilingTransactionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AssociatedFilingTransactionIT.java
@@ -539,10 +539,10 @@ class AssociatedFilingTransactionIT {
     }
 
     @Test
-    void shouldReturnSingleGetResponseWithOriginalDescriptionFieldOnChildObject() throws Exception {
+    void shouldSuccessfullyReturnSingleGetResponse() throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/existing_associated_filing_doc_with_action_date_and_document_metadata.json", StandardCharsets.UTF_8);
         existingDocumentJson = existingDocumentJson
                 .replaceAll("<barcode>", "")
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
@@ -569,9 +569,11 @@ class AssociatedFilingTransactionIT {
                         .terminationDate("2014-09-15"))
                 .actionDate("2014-09-15")
                 .links(new Links()
-                        .self("/company/%s/filing-history/%s".formatted(COMPANY_NUMBER, TRANSACTION_ID)))
+                        .self("/company/%s/filing-history/%s".formatted(COMPANY_NUMBER, TRANSACTION_ID))
+                        .documentMetadata("http://localhost:8080/document/document_metadata_id"))
                 .associatedFilings(List.of(
                         new AssociatedFiling()
+                                .actionDate("2015-10-05")
                                 .category("annual-return")
                                 .date("2005-05-10")
                                 .description("legacy")

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/get/AssociatedFilingsGetResponseMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/get/AssociatedFilingsGetResponseMapperTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +26,7 @@ class AssociatedFilingsGetResponseMapperTest {
     private static final String TYPE = "type";
     private static final String DESCRIPTION = "description";
     private static final String ORIGINAL_DESCRIPTION = "original description";
+    private static final String ACTION_DATE = "2015-10-05";
 
     @InjectMocks
     private AssociatedFilingsGetResponseMapper associatedFilingsGetResponseMapper;
@@ -39,6 +41,7 @@ class AssociatedFilingsGetResponseMapperTest {
         // given
         final List<AssociatedFiling> expected = List.of(
                 new AssociatedFiling()
+                        .actionDate(ACTION_DATE)
                         .category(CATEGORY)
                         .type(TYPE)
                         .originalDescription(ORIGINAL_DESCRIPTION)
@@ -91,6 +94,7 @@ class AssociatedFilingsGetResponseMapperTest {
     private static List<FilingHistoryAssociatedFiling> buildDocumentAssociatedFilingsList() {
         return List.of(
                 new FilingHistoryAssociatedFiling()
+                        .actionDate(Instant.parse("2015-10-05T00:00:00Z"))
                         .category(CATEGORY)
                         .type(TYPE)
                         .originalDescription(ORIGINAL_DESCRIPTION)

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/AssociatedFilingChildMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/AssociatedFilingChildMapperTest.java
@@ -25,6 +25,8 @@ class AssociatedFilingChildMapperTest {
 
     private static final String ENTITY_ID = "1234567890";
     private static final String NEWEST_REQUEST_DELTA_AT = "20151025185208001000";
+    private static final String ACTION_DATE = "2015-10-05T00:00:00Z";
+    private static final Instant INSTANT_ACTION_DATE = Instant.parse("2015-10-05T00:00:00Z");
 
     @InjectMocks
     private AssociatedFilingChildMapper associatedFilingChildMapper;
@@ -47,6 +49,7 @@ class AssociatedFilingChildMapperTest {
                 .externalData(new ExternalData()
                         .associatedFilings(List.of(
                                 new AssociatedFiling()
+                                        .actionDate(ACTION_DATE)
                                         .category("annual-return")
                                         .originalDescription("original description")
                                         .description("legacy")
@@ -56,6 +59,7 @@ class AssociatedFilingChildMapperTest {
                         )));
 
         FilingHistoryAssociatedFiling expected = new FilingHistoryAssociatedFiling()
+                .actionDate(INSTANT_ACTION_DATE)
                 .entityId(ENTITY_ID)
                 .deltaAt(NEWEST_REQUEST_DELTA_AT)
                 .category("annual-return")

--- a/src/test/resources/mongo_docs/associated_filings/existing_associated_filing_doc_with_action_date_and_document_metadata.json
+++ b/src/test/resources/mongo_docs/associated_filings/existing_associated_filing_doc_with_action_date_and_document_metadata.json
@@ -1,0 +1,52 @@
+{
+  "_id" : "<transaction_id>",
+  "company_number" : "<company_number>",
+  "data" : {
+    "associated_filings" : [
+      {
+        "action_date" : "2015-10-05T00:00:00Z",
+        "type" : "363(288)",
+        "description" : "legacy",
+        "category" : "annual-return",
+        "description_values" : {
+          "description" : "Secretary's particulars changed;director's particulars changed"
+        },
+        "date" : "2005-05-10T12:00:00.000Z",
+        "_entity_id": "<existing_child_entity_id>",
+        "delta_at": "<existing_child_delta_at>",
+        "original_description": "original description"
+      }
+    ],
+    "action_date" : "2014-09-15T00:00:00.000Z",
+    "category" : "officers",
+    "type" : "TM01",
+    "description" : "termination-director-company-with-name-termination-date",
+    "subcategory" : "termination",
+    "date" : "2014-09-15T23:21:18.000Z",
+    "description_values" : {
+      "termination_date" : "2014-09-15T00:00:00.000Z",
+      "officer_name" : "John Test Tester"
+    },
+    "links" : {
+      "self" : "/company/<company_number>/filing-history/<transaction_id>",
+      "document_metadata" : "/document/document_metadata_id"
+    }
+  },
+  "_barcode" : "<barcode>",
+  "delta_at" : "<parent_delta_at>",
+  "_entity_id" : "<parent_entity_id>",
+  "original_values" : {
+    "officer_name" : "John Test Tester",
+    "resignation_date" : "15/09/2014"
+  },
+  "original_description" : "Appointment Terminated, Director john tester",
+  "_document_id" : "000X3GI11F35672",
+  "updated": {
+    "at": "<updated_at>",
+    "by": "context_id"
+  },
+  "created": {
+    "at": "<created_at>",
+    "by": "context_id"
+  }
+}


### PR DESCRIPTION
## Describe the changes
The action date field wasn't on the FilingHistoryAssociatedFilings object as a field and so was not being mapped in both the GET response mapper and also the AssociatedFilingChildMapper for the upsert.

The rest of this ticket will be implemented in a separate PR.

Tested locally both sending a delta E2E and GET list + single responses on the API.

### Related Jira tickets

[DSND-2599](https://companieshouse.atlassian.net/browse/DSND-2599)

## Developer check list

### General

- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._


[DSND-2599]: https://companieshouse.atlassian.net/browse/DSND-2599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ