### PR TITLE
DSND-2599: Fix bug where barcode is not returned in java GET for Resolutions

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/get/ResolutionsGetResponseMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/get/ResolutionsGetResponseMapper.java
@@ -24,6 +24,7 @@ public class ResolutionsGetResponseMapper {
                         .stream()
                         .map(resolution ->
                                 new Resolution()
+                                        .barcode(resolution.getBarcode())
                                         .category(CategoryEnum.fromValue(resolution.getCategory()))
                                         .subcategory(resolution.getSubcategory())
                                         .description(resolution.getDescription())

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/ResolutionTransactionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/ResolutionTransactionIT.java
@@ -134,6 +134,7 @@ class ResolutionTransactionIT {
                 .pages(1)
                 .resolutions(List.of(
                         new Resolution()
+                                .barcode(BARCODE)
                                 .category(CategoryEnum.LIQUIDATION)
                                 .subcategory(List.of("voluntary", "resolution"))
                                 .description("liquidation-voluntary-special-resolution-to-wind-up-case-start-date")
@@ -202,6 +203,7 @@ class ResolutionTransactionIT {
                         .pages(1)
                         .resolutions(List.of(
                                 new Resolution()
+                                        .barcode(BARCODE)
                                         .category(CategoryEnum.LIQUIDATION)
                                         .subcategory(List.of("voluntary", "resolution"))
                                         .description(
@@ -769,6 +771,7 @@ class ResolutionTransactionIT {
                 .pages(1)
                 .resolutions(List.of(
                         new Resolution()
+                                .barcode(BARCODE)
                                 .category(CategoryEnum.LIQUIDATION)
                                 .subcategory(List.of("voluntary", "resolution"))
                                 .description("liquidation-voluntary-special-resolution-to-wind-up-case-start-date")
@@ -841,6 +844,7 @@ class ResolutionTransactionIT {
                         .pages(1)
                         .resolutions(List.of(
                                 new Resolution()
+                                        .barcode(BARCODE)
                                         .category(CategoryEnum.LIQUIDATION)
                                         .subcategory(List.of("voluntary", "resolution"))
                                         .description(

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/get/ResolutionsGetResponseMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/get/ResolutionsGetResponseMapperTest.java
@@ -7,6 +7,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -25,6 +28,11 @@ class ResolutionsGetResponseMapperTest {
     private static final String CATEGORY = "resolution";
     private static final String TYPE = "type";
     private static final String DESCRIPTION = "description";
+    private static final String BARCODE = "barcode";
+    private static final Object SUBCATEGORY = "subcategory";
+    private static final Instant INSTANT_NOW = Instant.now();
+    private static final String DATE = LocalDate.ofInstant(INSTANT_NOW, ZoneOffset.UTC).toString();
+    private static final String ORIGINAL_DESCRIPTION = "original description";
 
     @InjectMocks
     private ResolutionsGetResponseMapper resolutionsGetResponseMapper;
@@ -39,9 +47,13 @@ class ResolutionsGetResponseMapperTest {
         // given
         final List<Resolution> expected = List.of(
                 new Resolution()
+                        .barcode(BARCODE)
                         .category(CategoryEnum.RESOLUTION)
+                        .subcategory(SUBCATEGORY)
+                        .date(DATE)
                         .type(TYPE)
                         .description(DESCRIPTION)
+                        .originalDescription(ORIGINAL_DESCRIPTION)
                         .descriptionValues(DescriptionValues));
 
         when(descriptionValuesGetResponseMapper.map(any())).thenReturn(DescriptionValues);
@@ -92,9 +104,13 @@ class ResolutionsGetResponseMapperTest {
     private static List<FilingHistoryResolution> buildDocumentResolutionsList() {
         return List.of(
                 new FilingHistoryResolution()
+                        .barcode(BARCODE)
                         .category(CATEGORY)
-                        .type(TYPE)
                         .description(DESCRIPTION)
+                        .type(TYPE)
+                        .subcategory(SUBCATEGORY)
+                        .date(INSTANT_NOW)
+                        .originalDescription(ORIGINAL_DESCRIPTION)
                         .descriptionValues(new FilingHistoryDescriptionValues()));
     }
 }

--- a/src/test/resources/mongo_docs/resolutions/existing_resolution_doc.json
+++ b/src/test/resources/mongo_docs/resolutions/existing_resolution_doc.json
@@ -17,6 +17,7 @@
     },
     "resolutions" : [
       {
+        "barcode" : "<barcode>",
         "category" : "liquidation",
         "delta_at" : "<delta_at>",
         "description" : "liquidation-voluntary-special-resolution-to-wind-up-case-start-date",


### PR DESCRIPTION
## Describe the changes
Previously, the Java GET response would not return barcode for a resolution in the resolution array when it was present on the Mongo document - this PR fixes this.

### Related Jira tickets

[DSND-2599](https://companieshouse.atlassian.net/browse/DSND-2599)

## Developer check list

### General

- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._


[DSND-2599]: https://companieshouse.atlassian.net/browse/DSND-2599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ