### PR TITLE
DSND-2620: Remove null fields from resource changed delete request

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,18 @@ The service is implemented in Java 21 using Spring Boot 3.2
 
 ## Building the docker image
 
-    mvn compile jib:dockerBuild
+```bash
+mvn compile jib:dockerBuild
+```
 
 ## To make local changes
 
 Development mode is available for this service
 in [Docker CHS Development](https://github.com/companieshouse/docker-chs-development).
 
-    ./bin/chs-dev development enable filing-history-data-api
+```bash
+./bin/chs-dev development enable filing-history-data-api
+```
 
 This will clone the `filing-history-data-api` into the `./repositories` folder. Any changes to the
 code, or resources will automatically trigger a rebuild and relaunch.

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ResourceChangedRequestMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ResourceChangedRequestMapper.java
@@ -21,17 +21,17 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 public class ResourceChangedRequestMapper {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(NAMESPACE);
-    private static final String SERDES_ERROR_MSG = "Serialisation/deserialisation failed when mapping changed resource";
+    private static final String SERDES_ERROR_MSG = "Serialisation/deserialisation failed when mapping deleted data";
 
     private final ItemGetResponseMapper itemGetResponseMapper;
     private final Supplier<Instant> instantSupplier;
-    private final ObjectMapper nullCleaningObjectMapper;
+    private final ObjectMapper objectMapper;
 
     public ResourceChangedRequestMapper(ItemGetResponseMapper itemGetResponseMapper,
-                                        Supplier<Instant> instantSupplier, ObjectMapper nullCleaningObjectMapper) {
+                                        Supplier<Instant> instantSupplier, ObjectMapper objectMapper) {
         this.itemGetResponseMapper = itemGetResponseMapper;
         this.instantSupplier = instantSupplier;
-        this.nullCleaningObjectMapper = nullCleaningObjectMapper;
+        this.objectMapper = objectMapper;
     }
 
     public ChangedResource mapChangedResource(ResourceChangedRequest request) {
@@ -48,8 +48,8 @@ public class ResourceChangedRequestMapper {
             event.setType("deleted");
             try {
                 final String serialisedDeletedData =
-                        nullCleaningObjectMapper.writeValueAsString(itemGetResponseMapper.mapFilingHistoryItem(document));
-                changedResource.setDeletedData(nullCleaningObjectMapper.readValue(serialisedDeletedData, Object.class));
+                        objectMapper.writeValueAsString(itemGetResponseMapper.mapFilingHistoryItem(document));
+                changedResource.setDeletedData(objectMapper.readValue(serialisedDeletedData, Object.class));
             } catch (JsonProcessingException ex) {
                 LOGGER.error(SERDES_ERROR_MSG, ex, DataMapHolder.getLogMap());
                 throw new InternalServerErrorException(SERDES_ERROR_MSG);

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ResourceChangedRequestMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ResourceChangedRequestMapper.java
@@ -1,25 +1,37 @@
 package uk.gov.companieshouse.filinghistory.api.mapper.upsert;
 
+import static uk.gov.companieshouse.filinghistory.api.FilingHistoryApplication.NAMESPACE;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.util.function.Supplier;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
+import uk.gov.companieshouse.filinghistory.api.exception.InternalServerErrorException;
 import uk.gov.companieshouse.filinghistory.api.logging.DataMapHolder;
 import uk.gov.companieshouse.filinghistory.api.mapper.get.ItemGetResponseMapper;
 import uk.gov.companieshouse.filinghistory.api.model.ResourceChangedRequest;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Component
 public class ResourceChangedRequestMapper {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(NAMESPACE);
+    private static final String SERDES_ERROR_MSG = "Serialisation/deserialisation failed when mapping changed resource";
+
     private final ItemGetResponseMapper itemGetResponseMapper;
     private final Supplier<Instant> instantSupplier;
+    private final ObjectMapper nullCleaningObjectMapper;
 
     public ResourceChangedRequestMapper(ItemGetResponseMapper itemGetResponseMapper,
-            Supplier<Instant> instantSupplier) {
+                                        Supplier<Instant> instantSupplier, ObjectMapper nullCleaningObjectMapper) {
         this.itemGetResponseMapper = itemGetResponseMapper;
         this.instantSupplier = instantSupplier;
+        this.nullCleaningObjectMapper = nullCleaningObjectMapper;
     }
 
     public ChangedResource mapChangedResource(ResourceChangedRequest request) {
@@ -34,7 +46,14 @@ public class ResourceChangedRequestMapper {
 
         if (request.isDelete()) {
             event.setType("deleted");
-            changedResource.setDeletedData(itemGetResponseMapper.mapFilingHistoryItem(document));
+            try {
+                final String serialisedDeletedData =
+                        nullCleaningObjectMapper.writeValueAsString(itemGetResponseMapper.mapFilingHistoryItem(document));
+                changedResource.setDeletedData(nullCleaningObjectMapper.readValue(serialisedDeletedData, Object.class));
+            } catch (JsonProcessingException ex) {
+                LOGGER.error(SERDES_ERROR_MSG, ex, DataMapHolder.getLogMap());
+                throw new InternalServerErrorException(SERDES_ERROR_MSG);
+            }
         } else {
             event.setType("changed");
         }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ResourceChangedRequestMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ResourceChangedRequestMapperTest.java
@@ -1,22 +1,31 @@
 package uk.gov.companieshouse.filinghistory.api.mapper.upsert;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.function.Supplier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
 import uk.gov.companieshouse.api.filinghistory.ExternalData;
+import uk.gov.companieshouse.filinghistory.api.exception.InternalServerErrorException;
 import uk.gov.companieshouse.filinghistory.api.logging.DataMapHolder;
 import uk.gov.companieshouse.filinghistory.api.mapper.get.ItemGetResponseMapper;
 import uk.gov.companieshouse.filinghistory.api.model.ResourceChangedRequest;
@@ -43,6 +52,8 @@ class ResourceChangedRequestMapperTest {
     private ItemGetResponseMapper itemGetResponseMapper;
     @Mock
     private Supplier<Instant> instantSupplier;
+    @Mock
+    private ObjectMapper nullCleaningObjectMapper;
 
     @BeforeEach
     void setUp() {
@@ -71,17 +82,27 @@ class ResourceChangedRequestMapperTest {
     }
 
     @Test
-    void testDeletedResourceChangedMapper() {
+    void testDeletedResourceChangedMapper() throws Exception {
         // given
+        ObjectMapper objectMapper = new ObjectMapper()
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        final String deletedDataAsString = objectMapper.writeValueAsString(
+                new ExternalData()
+                        .transactionId("123"));
+        Object deletedDataAsObject = objectMapper.readValue(deletedDataAsString, Object.class);
+
         when(instantSupplier.get()).thenReturn(UPDATED_AT);
         when(itemGetResponseMapper.mapFilingHistoryItem(any())).thenReturn(deletedData);
+        when(nullCleaningObjectMapper.writeValueAsString(any())).thenReturn(deletedDataAsString);
+        when(nullCleaningObjectMapper.readValue(anyString(), eq(Object.class))).thenReturn(deletedDataAsObject);
 
         ResourceChangedRequest deleteResourceChangedRequest = new ResourceChangedRequest(filingHistoryDocument, true);
         ChangedResource expectedChangedResource = new ChangedResource()
                 .contextId(EXPECTED_CONTEXT_ID)
                 .resourceUri(RESOURCE_URI)
                 .resourceKind(FILING_HISTORY)
-                .deletedData(deletedData)
+                .deletedData(deletedDataAsObject)
                 .event(new ChangedResourceEvent()
                         .type(DELETED_EVENT_TYPE)
                         .publishedAt(UPDATED_AT.toString()));
@@ -92,5 +113,46 @@ class ResourceChangedRequestMapperTest {
         // then
         assertEquals(expectedChangedResource, actual);
         verify(itemGetResponseMapper).mapFilingHistoryItem(filingHistoryDocument);
+        verify(nullCleaningObjectMapper).writeValueAsString(deletedData);
+        verify(nullCleaningObjectMapper).readValue(deletedDataAsString, Object.class);
+    }
+
+    @Test
+    void shouldThrowInternalServerErrorForDeletedResourceChangedMapperOnSerialisation() throws Exception {
+        // given
+        when(instantSupplier.get()).thenReturn(UPDATED_AT);
+        when(itemGetResponseMapper.mapFilingHistoryItem(any())).thenReturn(deletedData);
+        when(nullCleaningObjectMapper.writeValueAsString(any())).thenThrow(JsonProcessingException.class);
+
+        ResourceChangedRequest deleteResourceChangedRequest = new ResourceChangedRequest(filingHistoryDocument, true);
+
+        // when
+        Executable executable = () -> mapper.mapChangedResource(deleteResourceChangedRequest);
+
+        // then
+        assertThrows(InternalServerErrorException.class, executable);
+        verify(itemGetResponseMapper).mapFilingHistoryItem(filingHistoryDocument);
+        verify(nullCleaningObjectMapper).writeValueAsString(deletedData);
+        verifyNoMoreInteractions(nullCleaningObjectMapper);
+    }
+
+    @Test
+    void shouldThrowInternalServerErrorForDeletedResourceChangedMapperOnDeserialisation() throws Exception {
+        // given
+        when(instantSupplier.get()).thenReturn(UPDATED_AT);
+        when(itemGetResponseMapper.mapFilingHistoryItem(any())).thenReturn(deletedData);
+        when(nullCleaningObjectMapper.writeValueAsString(any())).thenReturn("deletedDataAsString");
+        when(nullCleaningObjectMapper.readValue(anyString(), eq(Object.class))).thenThrow(JsonProcessingException.class);
+
+        ResourceChangedRequest deleteResourceChangedRequest = new ResourceChangedRequest(filingHistoryDocument, true);
+
+        // when
+        Executable executable = () -> mapper.mapChangedResource(deleteResourceChangedRequest);
+
+        // then
+        assertThrows(InternalServerErrorException.class, executable);
+        verify(itemGetResponseMapper).mapFilingHistoryItem(filingHistoryDocument);
+        verify(nullCleaningObjectMapper).writeValueAsString(deletedData);
+        verify(nullCleaningObjectMapper).readValue("deletedDataAsString", Object.class);
     }
 }


### PR DESCRIPTION
## Describe the changes
* Similar to the fix in company appointments api, we first serialise the deleted data into a String to remove null fields (as per the object mapper config). We then deserialise that string into a plain Java Object so it only contains non null fields.
* The serdes throws an exception which needs to be caught else it would have had to be added to all the method signatures upstream.

Tested locally.

### Related Jira tickets

[DSND-2620](https://companieshouse.atlassian.net/browse/DSND-2620)

## Developer check list

### General

- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._


[DSND-2620]: https://companieshouse.atlassian.net/browse/DSND-2620?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ