### PR TITLE
DSND-2367: Throw exception if child delete and feature disabled

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryController.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryController.java
@@ -85,7 +85,7 @@ public class FilingHistoryController {
         DataMapHolder.get()
                 .companyNumber(companyNumber)
                 .transactionId(transactionId);
-        LOGGER.info("Processing transaction upsert, entity_id: [%s]"
+        LOGGER.info("Processing transaction upsert, _entity_id: [%s]"
                 .formatted(requestBody.getInternalData().getEntityId()), DataMapHolder.getLogMap());
 
         serviceUpsertProcessor.processFilingHistory(transactionId, companyNumber, requestBody);

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegator.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegator.java
@@ -3,7 +3,7 @@ package uk.gov.companieshouse.filinghistory.api.mapper.delete;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.filinghistory.api.FilingHistoryApplication;
-import uk.gov.companieshouse.filinghistory.api.exception.InternalServerErrorException;
+import uk.gov.companieshouse.filinghistory.api.exception.BadRequestException;
 import uk.gov.companieshouse.filinghistory.api.logging.DataMapHolder;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDeleteAggregate;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument;
@@ -38,7 +38,7 @@ public class DeleteMapperDelegator {
             } else {
                 LOGGER.debug("Matched child resolution _entity_id: [%s]".formatted(entityId),
                         DataMapHolder.getLogMap());
-                throw new InternalServerErrorException("No mapper for child resolutions");
+                throw new BadRequestException("No mapper for child resolutions");
             }
         }
 
@@ -47,7 +47,7 @@ public class DeleteMapperDelegator {
             return Optional.empty();
         } else {
             LOGGER.debug("No match for _entity_id: [%s]".formatted(entityId), DataMapHolder.getLogMap());
-            throw new InternalServerErrorException("No match for _entity_id: [%s]".formatted(entityId));
+            throw new BadRequestException("No match for _entity_id: [%s]".formatted(entityId));
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorAspect.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorAspect.java
@@ -28,14 +28,16 @@ public class DeleteMapperDelegatorAspect {
         String entityId = (String) args[0];
         FilingHistoryDeleteAggregate aggregate = (FilingHistoryDeleteAggregate) args[1];
 
-        if (aggregate.getResolutionIndex() >= 0 || aggregate.getAnnotationIndex() >= 0
-                || aggregate.getAssociatedFilingIndex() >= 0) {
-            LOGGER.error("Cannot delete child while child deletion disabled, entity_id: [%s]"
+        if (aggregate.getResolutionIndex() >= 0
+                || aggregate.getAnnotationIndex() >= 0
+                || aggregate.getAssociatedFilingIndex() >= 0
+                || "RESOLUTIONS".equals(aggregate.getDocument().getData().getType())) {
+            LOGGER.error("Cannot delete child while child deletion disabled, _entity_id: [%s]"
                     .formatted(entityId), DataMapHolder.getLogMap());
-            throw new BadRequestException("Cannot delete child while child deletion disabled, entity_id: [%s]"
+            throw new BadRequestException("Cannot delete child while child deletion disabled, _entity_id: [%s]"
                     .formatted(entityId));
         } else {
-            LOGGER.debug("Matched parent entity_id: [%s]".formatted(entityId), DataMapHolder.getLogMap());
+            LOGGER.debug("Matched parent _entity_id: [%s]".formatted(entityId), DataMapHolder.getLogMap());
             return Optional.empty();
         }
     }

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorAspect.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorAspect.java
@@ -1,12 +1,15 @@
 package uk.gov.companieshouse.filinghistory.api.mapper.delete;
 
 import java.util.Optional;
+import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.filinghistory.api.FilingHistoryApplication;
+import uk.gov.companieshouse.filinghistory.api.exception.BadRequestException;
 import uk.gov.companieshouse.filinghistory.api.logging.DataMapHolder;
+import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDeleteAggregate;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
@@ -19,8 +22,21 @@ public class DeleteMapperDelegatorAspect {
     private static final Logger LOGGER = LoggerFactory.getLogger(FilingHistoryApplication.NAMESPACE);
 
     @Around("@annotation(DeleteChildTransactions)")
-    public Optional<FilingHistoryDocument> deleteChildTransactionsDisabled() {
+    public Optional<FilingHistoryDocument> deleteChildTransactionsDisabled(JoinPoint joinPoint) {
         LOGGER.debug("Deletion of child transactions disabled", DataMapHolder.getLogMap());
-        return Optional.empty();
+        Object[] args = joinPoint.getArgs();
+        String entityId = (String) args[0];
+        FilingHistoryDeleteAggregate aggregate = (FilingHistoryDeleteAggregate) args[1];
+
+        if (aggregate.getResolutionIndex() >= 0 || aggregate.getAnnotationIndex() >= 0
+                || aggregate.getAssociatedFilingIndex() >= 0) {
+            LOGGER.error("Cannot delete child while child deletion disabled, entity_id: [%s]"
+                    .formatted(entityId), DataMapHolder.getLogMap());
+            throw new BadRequestException("Cannot delete child while child deletion disabled, entity_id: [%s]"
+                    .formatted(entityId));
+        } else {
+            LOGGER.debug("Matched parent entity_id: [%s]".formatted(entityId), DataMapHolder.getLogMap());
+            return Optional.empty();
+        }
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorAspectFeatureDisabledIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorAspectFeatureDisabledIT.java
@@ -13,6 +13,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 import uk.gov.companieshouse.filinghistory.api.exception.BadRequestException;
+import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryData;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDeleteAggregate;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument;
 
@@ -36,7 +37,9 @@ class DeleteMapperDelegatorAspectFeatureDisabledIT {
 
         // when
         Optional<FilingHistoryDocument> actual = deleteMapperDelegator.delegateDelete(ENTITY_ID,
-                new FilingHistoryDeleteAggregate());
+                new FilingHistoryDeleteAggregate()
+                        .document(new FilingHistoryDocument()
+                                .data(new FilingHistoryData())));
 
         // then
         assertTrue(actual.isEmpty());
@@ -76,6 +79,21 @@ class DeleteMapperDelegatorAspectFeatureDisabledIT {
         // when
         Executable actual = () -> deleteMapperDelegator.delegateDelete(ENTITY_ID,
                 new FilingHistoryDeleteAggregate().associatedFilingIndex(0));
+
+        // then
+        assertThrows(BadRequestException.class, actual);
+        verifyNoInteractions(compositeResolutionDeleteMapper);
+    }
+
+    @Test
+    void shouldThrowBadRequestExceptionWhenCompositeResolutionMatch() {
+        // given
+
+        // when
+        Executable actual = () -> deleteMapperDelegator.delegateDelete(ENTITY_ID, new FilingHistoryDeleteAggregate()
+                .document(new FilingHistoryDocument()
+                        .data(new FilingHistoryData()
+                                .type("RESOLUTIONS"))));
 
         // then
         assertThrows(BadRequestException.class, actual);

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorAspectFeatureDisabledIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorAspectFeatureDisabledIT.java
@@ -1,15 +1,18 @@
 package uk.gov.companieshouse.filinghistory.api.mapper.delete;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.verifyNoInteractions;
 
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import uk.gov.companieshouse.filinghistory.api.exception.BadRequestException;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDeleteAggregate;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument;
 
@@ -29,7 +32,7 @@ class DeleteMapperDelegatorAspectFeatureDisabledIT {
     }
 
     @Test
-    void shouldDeleteChildTransactionsWhenFeatureEnabled() {
+    void shouldDeleteChildTransactionsWhenFeatureDisabled() {
 
         // when
         Optional<FilingHistoryDocument> actual = deleteMapperDelegator.delegateDelete(ENTITY_ID,
@@ -37,6 +40,45 @@ class DeleteMapperDelegatorAspectFeatureDisabledIT {
 
         // then
         assertTrue(actual.isEmpty());
+        verifyNoInteractions(compositeResolutionDeleteMapper);
+    }
+
+    @Test
+    void shouldThrowBadRequestExceptionWhenResolutionChildMatch() {
+        // given
+
+        // when
+        Executable actual = () -> deleteMapperDelegator.delegateDelete(ENTITY_ID,
+                new FilingHistoryDeleteAggregate().resolutionIndex(0));
+
+        // then
+        assertThrows(BadRequestException.class, actual);
+        verifyNoInteractions(compositeResolutionDeleteMapper);
+    }
+
+    @Test
+    void shouldThrowBadRequestExceptionWhenAnnotationChildMatch() {
+        // given
+
+        // when
+        Executable actual = () -> deleteMapperDelegator.delegateDelete(ENTITY_ID,
+                new FilingHistoryDeleteAggregate().annotationIndex(0));
+
+        // then
+        assertThrows(BadRequestException.class, actual);
+        verifyNoInteractions(compositeResolutionDeleteMapper);
+    }
+
+    @Test
+    void shouldThrowBadRequestExceptionWhenAssociatedFilingChildMatch() {
+        // given
+
+        // when
+        Executable actual = () -> deleteMapperDelegator.delegateDelete(ENTITY_ID,
+                new FilingHistoryDeleteAggregate().associatedFilingIndex(0));
+
+        // then
+        assertThrows(BadRequestException.class, actual);
         verifyNoInteractions(compositeResolutionDeleteMapper);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorAspectTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorAspectTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.filinghistory.api.exception.BadRequestException;
+import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryData;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDeleteAggregate;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument;
 
@@ -26,7 +27,9 @@ class DeleteMapperDelegatorAspectTest {
     @Test
     void shouldReturnEmptyWhenNoChildMatches() {
         // given
-        when(joinPoint.getArgs()).thenReturn(new Object[]{"entity id", new FilingHistoryDeleteAggregate()});
+        when(joinPoint.getArgs()).thenReturn(new Object[]{"entity id", new FilingHistoryDeleteAggregate()
+                .document(new FilingHistoryDocument()
+                    .data(new FilingHistoryData()))});
 
         // when
         Optional<FilingHistoryDocument> actual = aspect.deleteChildTransactionsDisabled(joinPoint);
@@ -66,6 +69,22 @@ class DeleteMapperDelegatorAspectTest {
         // given
         when(joinPoint.getArgs()).thenReturn(
                 new Object[]{"entity id", new FilingHistoryDeleteAggregate().associatedFilingIndex(0)});
+
+        // when
+        Executable actual = () -> aspect.deleteChildTransactionsDisabled(joinPoint);
+
+        // then
+        assertThrows(BadRequestException.class, actual);
+    }
+
+    @Test
+    void shouldThrowBadRequestExceptionWhenCompositeResolutionMatch() {
+        // given
+        when(joinPoint.getArgs()).thenReturn(
+                new Object[]{"entity id", new FilingHistoryDeleteAggregate()
+                        .document(new FilingHistoryDocument()
+                        .data(new FilingHistoryData()
+                                .type("RESOLUTIONS")))});
 
         // when
         Executable actual = () -> aspect.deleteChildTransactionsDisabled(joinPoint);

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorAspectTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorAspectTest.java
@@ -1,21 +1,76 @@
 package uk.gov.companieshouse.filinghistory.api.mapper.delete;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 import java.util.Optional;
+import org.aspectj.lang.JoinPoint;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.filinghistory.api.exception.BadRequestException;
+import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDeleteAggregate;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument;
 
+@ExtendWith(MockitoExtension.class)
 class DeleteMapperDelegatorAspectTest {
 
     private final DeleteMapperDelegatorAspect aspect = new DeleteMapperDelegatorAspect();
 
+    @Mock
+    private JoinPoint joinPoint;
+
     @Test
-    void shouldReturnEmpty() {
+    void shouldReturnEmptyWhenNoChildMatches() {
+        // given
+        when(joinPoint.getArgs()).thenReturn(new Object[]{"entity id", new FilingHistoryDeleteAggregate()});
+
         // when
-        Optional<FilingHistoryDocument> actual = aspect.deleteChildTransactionsDisabled();
+        Optional<FilingHistoryDocument> actual = aspect.deleteChildTransactionsDisabled(joinPoint);
 
         // then
         assertTrue(actual.isEmpty());
+    }
+
+    @Test
+    void shouldThrowBadRequestExceptionWhenResolutionChildMatch() {
+        // given
+        when(joinPoint.getArgs()).thenReturn(
+                new Object[]{"entity id", new FilingHistoryDeleteAggregate().resolutionIndex(0)});
+
+        // when
+        Executable actual = () -> aspect.deleteChildTransactionsDisabled(joinPoint);
+
+        // then
+        assertThrows(BadRequestException.class, actual);
+    }
+
+    @Test
+    void shouldThrowBadRequestExceptionWhenAnnotationChildMatch() {
+        // given
+        when(joinPoint.getArgs()).thenReturn(
+                new Object[]{"entity id", new FilingHistoryDeleteAggregate().annotationIndex(0)});
+
+        // when
+        Executable actual = () -> aspect.deleteChildTransactionsDisabled(joinPoint);
+
+        // then
+        assertThrows(BadRequestException.class, actual);
+    }
+
+    @Test
+    void shouldThrowBadRequestExceptionWhenAssociatedFilingChildMatch() {
+        // given
+        when(joinPoint.getArgs()).thenReturn(
+                new Object[]{"entity id", new FilingHistoryDeleteAggregate().associatedFilingIndex(0)});
+
+        // when
+        Executable actual = () -> aspect.deleteChildTransactionsDisabled(joinPoint);
+
+        // then
+        assertThrows(BadRequestException.class, actual);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.function.Executable;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.filinghistory.api.exception.InternalServerErrorException;
+import uk.gov.companieshouse.filinghistory.api.exception.BadRequestException;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryData;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDeleteAggregate;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument;
@@ -70,7 +70,7 @@ class DeleteMapperDelegatorTest {
     }
 
     @Test
-    void shouldThrowInternalServerErrorExceptionWhenChildResolutionAndResEntityIdMatches() {
+    void shouldThrowBadRequestExceptionWhenChildResolutionAndResEntityIdMatches() {
         // given
         FilingHistoryDocument documentCopy = new FilingHistoryDocument()
                 .entityId(ENTITY_ID)
@@ -89,12 +89,12 @@ class DeleteMapperDelegatorTest {
         Executable actual = () -> deleteMapperDelegator.delegateDelete(CHILD_ENTITY_ID, aggregate);
 
         // then
-        assertThrows(InternalServerErrorException.class, actual);
+        assertThrows(BadRequestException.class, actual);
         verify(documentCopier).deepCopy(document);
     }
 
     @Test
-    void shouldThrowInternalServerErrorExceptionWhenNoEntityIdMatchesAndEmptyResolutionsList() {
+    void shouldThrowBadRequestExceptionWhenNoEntityIdMatchesAndEmptyResolutionsList() {
         // given
         FilingHistoryDocument documentCopy = new FilingHistoryDocument()
                 .entityId(ENTITY_ID)
@@ -109,12 +109,12 @@ class DeleteMapperDelegatorTest {
         Executable actual = () -> deleteMapperDelegator.delegateDelete(CHILD_ENTITY_ID, aggregate);
 
         // then
-        assertThrows(InternalServerErrorException.class, actual);
+        assertThrows(BadRequestException.class, actual);
         verify(documentCopier).deepCopy(document);
     }
 
     @Test
-    void shouldThrowInternalServerErrorExceptionWhenNoEntityIdMatchesAndHasResolution() {
+    void shouldThrowBadRequestExceptionWhenNoEntityIdMatchesAndHasResolution() {
         // given
         FilingHistoryDocument documentCopy = new FilingHistoryDocument()
                 .entityId(ENTITY_ID)
@@ -129,7 +129,7 @@ class DeleteMapperDelegatorTest {
         Executable actual = () -> deleteMapperDelegator.delegateDelete(CHILD_ENTITY_ID, aggregate);
 
         // then
-        assertThrows(InternalServerErrorException.class, actual);
+        assertThrows(BadRequestException.class, actual);
         verify(documentCopier).deepCopy(document);
     }
 


### PR DESCRIPTION
## Describe the changes
* When deletion of children disabled ```DELETE_CHILD_TRANSACTIONS_DISABLED=true```, returns 400 bad request when attempting to delete a child or a composite resolution.
* Top level deletes with no matching children work as normal.

### Related Jira tickets

[DSND-2367](https://companieshouse.atlassian.net/browse/DSND-2367)

## Developer check list

### General

- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._


[DSND-2367]: https://companieshouse.atlassian.net/browse/DSND-2367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ