### PR TITLE
DSND-2657: Persist all original values as strings

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/OriginalValuesMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/OriginalValuesMapper.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.filinghistory.api.mapper.upsert;
 
-import static uk.gov.companieshouse.filinghistory.api.mapper.DateUtils.stringToInstant;
-
 import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.filinghistory.InternalDataOriginalValues;
@@ -15,8 +13,8 @@ public class OriginalValuesMapper {
                 .map(values -> new FilingHistoryOriginalValues()
                         .officerName(values.getOfficerName())
                         .resignationDate(values.getResignationDate())
-                        .chargeCreationDate(stringToInstant(values.getChargeCreationDate()))
-                        .propertyAcquiredDate(stringToInstant(values.getPropertyAcquiredDate()))
+                        .chargeCreationDate(values.getChargeCreationDate())
+                        .propertyAcquiredDate(values.getPropertyAcquiredDate())
                         .appointmentDate(values.getAppointmentDate())
                         .caseStartDate(values.getCaseStartDate())
                         .caseEndDate(values.getCaseEndDate())

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/model/mongo/FilingHistoryOriginalValues.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/model/mongo/FilingHistoryOriginalValues.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.filinghistory.api.model.mongo;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.time.Instant;
 import java.util.Objects;
 import org.springframework.data.mongodb.core.mapping.Field;
 
@@ -17,11 +16,11 @@ public class FilingHistoryOriginalValues {
 
     @Field("charge_creation_date")
     @JsonProperty("charge_creation_date")
-    private Instant chargeCreationDate;
+    private Object chargeCreationDate;
 
     @Field("property_acquired_date")
     @JsonProperty("property_acquired_date")
-    private Instant propertyAcquiredDate;
+    private Object propertyAcquiredDate;
 
     @Field("appointment_date")
     @JsonProperty("appointment_date")
@@ -109,20 +108,20 @@ public class FilingHistoryOriginalValues {
         return this;
     }
 
-    public Instant getChargeCreationDate() {
+    public Object getChargeCreationDate() {
         return chargeCreationDate;
     }
 
-    public FilingHistoryOriginalValues chargeCreationDate(Instant chargeCreationDate) {
+    public FilingHistoryOriginalValues chargeCreationDate(String chargeCreationDate) {
         this.chargeCreationDate = chargeCreationDate;
         return this;
     }
 
-    public Instant getPropertyAcquiredDate() {
+    public Object getPropertyAcquiredDate() {
         return propertyAcquiredDate;
     }
 
-    public FilingHistoryOriginalValues propertyAcquiredDate(Instant propertyAcquiredDate) {
+    public FilingHistoryOriginalValues propertyAcquiredDate(String propertyAcquiredDate) {
         this.propertyAcquiredDate = propertyAcquiredDate;
         return this;
     }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerIT.java
@@ -265,6 +265,68 @@ class FilingHistoryControllerIT {
     }
 
     @Test
+    void shouldUpdateExistingDocumentWithLegacyOriginalValuesAndReturn200OK() throws Exception {
+        // given
+        String existingDocumentJson = IOUtils.resourceToString(
+                "/mongo_docs/existing-legacy-original-values-document.json", StandardCharsets.UTF_8);
+        existingDocumentJson = existingDocumentJson
+                .replaceAll("<transaction_id>", TRANSACTION_ID)
+                .replaceAll("<barcode>", BARCODE)
+                .replaceAll("<company_number>", COMPANY_NUMBER)
+                .replaceAll("<entity_id>", ENTITY_ID);
+        mongoTemplate.insert(Document.parse(existingDocumentJson), FILING_HISTORY_COLLECTION);
+
+        String expectedDocumentJson = IOUtils.resourceToString(
+                "/mongo_docs/expected-legacy-original-values-document.json", StandardCharsets.UTF_8);
+        expectedDocumentJson = expectedDocumentJson
+                .replaceAll("<barcode>", BARCODE)
+                .replaceAll("<transaction_id>", TRANSACTION_ID)
+                .replaceAll("<company_number>", COMPANY_NUMBER)
+                .replaceAll("<entity_id>", ENTITY_ID)
+                .replaceAll("<delta_at>", NEWEST_REQUEST_DELTA_AT)
+                .replaceAll("<updated_at>", UPDATED_AT.toString())
+                .replaceAll("<context_id>", CONTEXT_ID);
+        final FilingHistoryDocument expectedDocument =
+                objectMapper.readValue(expectedDocumentJson, FilingHistoryDocument.class);
+
+        String requestBody = IOUtils.resourceToString(
+                "/put_requests/mr01s/put_request_MR01.json", StandardCharsets.UTF_8);
+        requestBody = requestBody
+                .replaceAll("<delta_at>", NEWEST_REQUEST_DELTA_AT)
+                .replaceAll("<company_number>", COMPANY_NUMBER)
+                .replaceAll("<transaction_id>", TRANSACTION_ID)
+                .replaceAll("<entity_id>", ENTITY_ID)
+                .replaceAll("<barcode>", BARCODE)
+                .replaceAll("<updated_at>", UPDATED_AT.toString())
+                .replaceAll("<context_id>", CONTEXT_ID);
+
+        when(instantSupplier.get()).thenReturn(UPDATED_AT);
+        stubFor(post(urlEqualTo(RESOURCE_CHANGED_URI))
+                .willReturn(aResponse()
+                        .withStatus(200)));
+
+        // when
+        ResultActions result = mockMvc.perform(put(PUT_REQUEST_URI, COMPANY_NUMBER, TRANSACTION_ID)
+                .header("ERIC-Identity", "123")
+                .header("ERIC-Identity-Type", "key")
+                .header("ERIC-Authorised-Key-Privileges", "internal-app")
+                .header("X-Request-Id", CONTEXT_ID)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(requestBody));
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk());
+        result.andExpect(MockMvcResultMatchers.header().string(LOCATION, SELF_LINK));
+
+        FilingHistoryDocument actualDocument = mongoTemplate.findById(TRANSACTION_ID, FilingHistoryDocument.class);
+        assertEquals(expectedDocument, actualDocument);
+
+        verify(instantSupplier, times(2)).get();
+        WireMock.verify(
+                requestMadeFor(new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResource())));
+    }
+
+    @Test
     void shouldGetCompanyFilingHistoryListAndReturn200OK() throws Exception {
         // given
         final FilingHistoryList expectedResponseBody = new FilingHistoryList()

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/OriginalValuesMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/OriginalValuesMapperTest.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.filinghistory.api.mapper.upsert;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-import java.time.Instant;
 import org.junit.jupiter.api.Test;
 import uk.gov.companieshouse.api.filinghistory.InternalDataOriginalValues;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryOriginalValues;
@@ -13,9 +12,7 @@ class OriginalValuesMapperTest {
     private static final String OFFICER_NAME = "John Tester";
     private static final String RESIGNATION_DATE = "06/08/2011";
     private static final String CHARGE_CREATION_DATE = "2011-06-01T00:00:00.00Z";
-    private static final Instant CHARGE_CREATION_DATE_INSTANT = Instant.parse(CHARGE_CREATION_DATE);
     private static final String PROPERTY_ACQUIRED_DATE = "2011-06-02T00:00:00.00Z";
-    private static final Instant PROPERTY_ACQUIRED_DATE_INSTANT = Instant.parse(PROPERTY_ACQUIRED_DATE);
     private static final String APPOINTMENT_DATE = "03/06/2011";
     private static final String CASE_START_DATE = "04/06/2011";
     private static final String CASE_END_DATE = "05/06/2011";
@@ -63,8 +60,8 @@ class OriginalValuesMapperTest {
 
         FilingHistoryOriginalValues expected = new FilingHistoryOriginalValues()
                 .resignationDate(RESIGNATION_DATE)
-                .chargeCreationDate(CHARGE_CREATION_DATE_INSTANT)
-                .propertyAcquiredDate(PROPERTY_ACQUIRED_DATE_INSTANT)
+                .chargeCreationDate(CHARGE_CREATION_DATE)
+                .propertyAcquiredDate(PROPERTY_ACQUIRED_DATE)
                 .appointmentDate(APPOINTMENT_DATE)
                 .caseStartDate(CASE_START_DATE)
                 .caseEndDate(CASE_END_DATE)

--- a/src/test/resources/mongo_docs/existing-legacy-original-values-document.json
+++ b/src/test/resources/mongo_docs/existing-legacy-original-values-document.json
@@ -1,0 +1,28 @@
+{
+  "_id" : "<transaction_id>",
+  "company_number" : "<company_number>",
+  "original_values" : {
+    "charge_creation_date" : ISODate("2014-09-29T00:00:00Z")
+  },
+  "_entity_id" : "<entity_id>",
+  "data" : {
+    "subcategory" : "create",
+    "type" : "MR01",
+    "date" : "2014-10-02T00:00:00Z",
+    "description_values" : {
+      "charge_creation_date" : "2014-09-29T00:00:00Z",
+      "charge_number" : "1234567890"
+    },
+    "description" : "mortgage-create-with-deed-with-charge-number-charge-creation-date",
+    "action_date" : "2014-09-29T00:00:00Z",
+    "category" : "mortgage",
+    "pages" : 5,
+    "links" : {
+      "document_metadata" : "/document/metadata",
+      "self" : "/company/<company_number>/filing-history/<transaction_id>"
+    }
+  },
+  "original_description" : "Registration of a charge / charge code 1234567890",
+  "_barcode" : "<barcode>",
+  "_document_id" : "document_id"
+}

--- a/src/test/resources/mongo_docs/expected-legacy-original-values-document.json
+++ b/src/test/resources/mongo_docs/expected-legacy-original-values-document.json
@@ -1,0 +1,33 @@
+{
+  "_id" : "<transaction_id>",
+  "company_number" : "<company_number>",
+  "original_values" : {
+    "charge_creation_date" : "29/09/2014"
+  },
+  "_entity_id" : "<entity_id>",
+  "data" : {
+    "subcategory" : "create",
+    "type" : "MR01",
+    "date" : "2014-10-02T00:00:00Z",
+    "description_values" : {
+      "charge_creation_date" : "2014-09-29T00:00:00Z",
+      "charge_number" : "1234567890"
+    },
+    "description" : "mortgage-create-with-deed-with-charge-number-charge-creation-date",
+    "action_date" : "2014-09-29T00:00:00Z",
+    "category" : "mortgage",
+    "pages" : 5,
+    "links" : {
+      "document_metadata" : "/document/metadata",
+      "self" : "/company/<company_number>/filing-history/<transaction_id>"
+    }
+  },
+  "original_description" : "Registration of a charge / charge code 1234567890",
+  "_barcode" : "<barcode>",
+  "_document_id" : "document_id",
+  "delta_at" : "<delta_at>",
+  "updated": {
+    "at": "<updated_at>",
+    "by": "<context_id>"
+  }
+}

--- a/src/test/resources/put_requests/mr01s/put_request_MR01.json
+++ b/src/test/resources/put_requests/mr01s/put_request_MR01.json
@@ -1,0 +1,32 @@
+{
+  "external_data": {
+    "transaction_id": "<transaction_id>",
+    "barcode": "<barcode>",
+    "subcategory": "create",
+    "type": "MR01",
+    "date": "2014-10-02T00:00:00Z",
+    "description_values": {
+      "charge_creation_date": "2014-09-29T00:00:00Z",
+      "charge_number": "1234567890"
+    },
+    "description": "mortgage-create-with-deed-with-charge-number-charge-creation-date",
+    "action_date": "2014-09-29T00:00:00Z",
+    "category": "mortgage",
+    "links": {
+      "self": "/company/<company_number>/filing-history/<transaction_id>"
+    }
+  },
+  "internal_data": {
+    "company_number": "<company_number>",
+    "delta_at": "<delta_at>",
+    "entity_id": "<entity_id>",
+    "updated_at": "<updated_at>",
+    "updated_by": "<context_id>",
+    "document_id": "document_id",
+    "transaction_kind": "top-level",
+    "original_values": {
+      "charge_creation_date": "29/09/2014"
+    },
+    "original_description": "Registration of a charge / charge code 1234567890"
+  }
+}

--- a/src/test/resources/put_requests/tm01s/put_request_TM01.json
+++ b/src/test/resources/put_requests/tm01s/put_request_TM01.json
@@ -29,9 +29,6 @@
       "officer_name" : "John Test Tester",
       "resignation_date" : "15/09/2014"
     },
-    "original_description" : "Appointment Terminated, Director john tester",
-    "links" : {
-      "self" : "/company/<company_number>/filing-history/<transaction_id>"
-    }
+    "original_description" : "Appointment Terminated, Director john tester"
   }
 }


### PR DESCRIPTION
## Describe the changes
* The types of charge_creation_date and property_acquired_date are Object to handle updating of legacy data where those fields are ISODates in Mongo.

### Related Jira tickets

[DSND-2657](https://companieshouse.atlassian.net/browse/DSND-2657)

## Developer check list

### General

- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._


[DSND-2657]: https://companieshouse.atlassian.net/browse/DSND-2657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ