### PR TITLE
DSND-2658: Do not overwrite true paper filed

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/AbstractTransactionMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/AbstractTransactionMapper.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.filinghistory.api.mapper.upsert;
 
+import static java.lang.Boolean.TRUE;
+
 import java.time.Instant;
 import uk.gov.companieshouse.api.filinghistory.InternalFilingHistoryApi;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryData;
@@ -29,9 +31,15 @@ public abstract class AbstractTransactionMapper {
 
     public FilingHistoryDocument mapExistingFilingHistory(InternalFilingHistoryApi request,
             FilingHistoryDocument existingDocument, Instant instant) {
+        FilingHistoryData existingData = existingDocument.getData();
+
+        Boolean paperFiled = existingData.getPaperFiled();
+        if (!TRUE.equals(paperFiled)) {
+            paperFiled = request.getExternalData().getPaperFiled();
+        }
         return mapTopLevelFields(request, existingDocument, instant)
-                .data(mapFilingHistoryData(request, existingDocument.getData())
-                        .paperFiled(request.getExternalData().getPaperFiled()));
+                .data(mapFilingHistoryData(request, existingData)
+                        .paperFiled(paperFiled));
     }
 
     protected abstract FilingHistoryData mapFilingHistoryData(InternalFilingHistoryApi request, FilingHistoryData data);

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/DataMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/DataMapper.java
@@ -41,7 +41,6 @@ public class DataMapper {
                 .category(data.getCategory().toString())
                 .description(data.getDescription())
                 .descriptionValues(descriptionValuesMapper.map(data.getDescriptionValues()))
-                .actionDate(stringToInstant(data.getActionDate()))
-                .paperFiled(data.getPaperFiled());
+                .actionDate(stringToInstant(data.getActionDate()));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AnnotationTransactionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AnnotationTransactionIT.java
@@ -303,7 +303,7 @@ class AnnotationTransactionIT {
     }
 
     @Test
-    void shouldInsertParentFieldsAndNotChangeAnnotationAndReturn200OK() throws Exception {
+    void shouldInsertParentFieldsWithoutChangingAnnotationOrTruePaperFiledAndReturn200OK() throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
                 "/mongo_docs/annotations/existing_annotation_doc_with_no_parent.json", StandardCharsets.UTF_8);
@@ -337,7 +337,7 @@ class AnnotationTransactionIT {
                 objectMapper.readValue(expectedDocumentJson, FilingHistoryDocument.class);
 
         String requestBody = IOUtils.resourceToString(
-                "/put_requests/tm01s/put_request_TM01.json", StandardCharsets.UTF_8);
+                "/put_requests/tm01s/put_request_TM01_electronic.json", StandardCharsets.UTF_8);
         requestBody = requestBody
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<delta_at>", NEWEST_REQUEST_DELTA_AT)

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/AnnotationTransactionMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/AnnotationTransactionMapperTest.java
@@ -163,7 +163,6 @@ class AnnotationTransactionMapperTest {
     void shouldMapAnnotationToExistingDocumentWhenTopLevelAnnotation() {
         // given
         ExternalData externalData = new ExternalData()
-                .paperFiled(true)
                 .barcode(BARCODE);
         InternalFilingHistoryApi request = new InternalFilingHistoryApi()
                 .internalData(new InternalData()
@@ -184,11 +183,17 @@ class AnnotationTransactionMapperTest {
                 .documentMetadata("metadata");
         FilingHistoryData existingData = new FilingHistoryData()
                 .links(existingLinks)
+                .paperFiled(true)
                 .annotations(annotationList);
         FilingHistoryDocument existingDocument = new FilingHistoryDocument()
                 .data(existingData)
                 .created(existingTimestamp)
                 .updated(existingTimestamp);
+
+        FilingHistoryData mappedData = new FilingHistoryData()
+                .category("annotation")
+                .paperFiled(true)
+                .annotations(annotationList);
 
         FilingHistoryData expectedData = new FilingHistoryData()
                 .category("annotation")
@@ -208,7 +213,7 @@ class AnnotationTransactionMapperTest {
                 .barcode(BARCODE)
                 .data(expectedData);
 
-        when(dataMapper.map(any(), any())).thenReturn(expectedData);
+        when(dataMapper.map(any(), any())).thenReturn(mappedData);
 
         // when
         FilingHistoryDocument actual = annotationTransactionMapper.mapExistingFilingHistory(

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/DataMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/DataMapperTest.java
@@ -61,8 +61,7 @@ class DataMapperTest {
                 .subcategory((String) null)
                 .description("description")
                 .descriptionValues(expectedDescriptionValues)
-                .actionDate(ACTION_AND_TERMINATION_DATE_AS_INSTANT)
-                .paperFiled(true);
+                .actionDate(ACTION_AND_TERMINATION_DATE_AS_INSTANT);
 
         // when
         final FilingHistoryData actualData = dataMapper.map(buildRequestExternalData(), new FilingHistoryData());
@@ -86,8 +85,7 @@ class DataMapperTest {
                 .subcategory(SUBCATEGORY)
                 .description("description")
                 .descriptionValues(expectedDescriptionValues)
-                .actionDate(ACTION_AND_TERMINATION_DATE_AS_INSTANT)
-                .paperFiled(true);
+                .actionDate(ACTION_AND_TERMINATION_DATE_AS_INSTANT);
 
         // when
         final FilingHistoryData actualData = dataMapper.map(externalData, new FilingHistoryData());
@@ -111,8 +109,7 @@ class DataMapperTest {
                 .subcategory(List.of("voluntary", "certificate"))
                 .description("description")
                 .descriptionValues(expectedDescriptionValues)
-                .actionDate(ACTION_AND_TERMINATION_DATE_AS_INSTANT)
-                .paperFiled(true);
+                .actionDate(ACTION_AND_TERMINATION_DATE_AS_INSTANT);
 
         // when
         final FilingHistoryData actualData = dataMapper.map(externalData, new FilingHistoryData());
@@ -151,8 +148,7 @@ class DataMapperTest {
                 .description("description")
                 .descriptionValues(expectedDescriptionValues)
                 .annotations(List.of(new FilingHistoryAnnotation().annotation("annotation")))
-                .actionDate(ACTION_AND_TERMINATION_DATE_AS_INSTANT)
-                .paperFiled(true);
+                .actionDate(ACTION_AND_TERMINATION_DATE_AS_INSTANT);
 
         final FilingHistoryData existingData = new FilingHistoryData()
                 .annotations(List.of(new FilingHistoryAnnotation().annotation("annotation")));
@@ -177,7 +173,6 @@ class DataMapperTest {
                 .descriptionValues(requestDescriptionValues)
                 .pages(1) // should not be mapped, persisted by document store sub delta
                 .actionDate(ACTION_AND_TERMINATION_DATE_AS_LOCAL_DATE)
-                .paperFiled(true)
                 .links(requestLinks);
     }
 }

--- a/src/test/resources/put_requests/tm01s/put_request_TM01_electronic.json
+++ b/src/test/resources/put_requests/tm01s/put_request_TM01_electronic.json
@@ -1,0 +1,36 @@
+{
+  "external_data" : {
+    "transaction_id": "<transaction_id>",
+    "barcode": "<barcode>",
+    "action_date" : "2014-09-15T00:00:00.000Z",
+    "category" : "officers",
+    "type" : "TM01",
+    "description" : "termination-director-company-with-name-termination-date",
+    "subcategory" : "termination",
+    "date" : "2014-09-15T23:21:18.000Z",
+    "description_values" : {
+      "termination_date" : "2014-09-15T00:00:00.000Z",
+      "officer_name" : "John Test Tester"
+    },
+    "links": {
+      "self": "/company/<company_number>/filing-history/<transaction_id>"
+    }
+  },
+  "internal_data": {
+    "company_number": "<company_number>",
+    "delta_at" : "<delta_at>",
+    "entity_id" : "<entity_id>",
+    "updated_at" : "<updated_at>",
+    "updated_by": "<context_id>",
+    "document_id" : "000X3GI11F35672",
+    "transaction_kind": "top-level",
+    "original_values" : {
+      "officer_name" : "John Test Tester",
+      "resignation_date" : "15/09/2014"
+    },
+    "original_description" : "Appointment Terminated, Director john tester",
+    "links" : {
+      "self" : "/company/<company_number>/filing-history/<transaction_id>"
+    }
+  }
+}


### PR DESCRIPTION
## Describe the changes
* If paper filed is true on an existing document, then it should never be changed.
* Previously when inserting a non-paper filed parent onto a paper filed child or if an update delta is sent with a different barcode from the first the paper filed field would be overwritten.

### Related Jira tickets

[DSND-2658](https://companieshouse.atlassian.net/browse/DSND-2658)

## Developer check list

### General

- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._
