### PR TITLE
DSND-2691: Stop persisting original_description for associated filings

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/AssociatedFilingChildMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/AssociatedFilingChildMapper.java
@@ -27,7 +27,6 @@ public class AssociatedFilingChildMapper implements ChildMapper<FilingHistoryAss
         return existingAssociatedFiling
                 .actionDate(stringToInstant(requestAssociatedFilings.getActionDate()))
                 .entityId(internalData.getEntityId())
-                .originalDescription(requestAssociatedFilings.getOriginalDescription())
                 .deltaAt(internalData.getDeltaAt())
                 .category(requestAssociatedFilings.getCategory())
                 .date(stringToInstant(requestAssociatedFilings.getDate()))

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/TopLevelTransactionMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/TopLevelTransactionMapper.java
@@ -41,7 +41,14 @@ public class TopLevelTransactionMapper extends AbstractTransactionMapper {
 
         if (externalData.getAssociatedFilings() != null && !externalData.getAssociatedFilings().isEmpty()) {
             childListMapper.mapChildList(request, mappedData.getAssociatedFilings(), mappedData::associatedFilings);
+
+            data.getAssociatedFilings().stream()
+                    .filter(af -> request.getInternalData().getEntityId().equals(af.getEntityId()))
+                    .findFirst()
+                    .ifPresent(af -> af.originalDescription(
+                            request.getExternalData().getAssociatedFilings().getFirst().getOriginalDescription()));
         }
+
         return mappedData;
     }
 

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AssociatedFilingTransactionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AssociatedFilingTransactionIT.java
@@ -598,7 +598,6 @@ class AssociatedFilingTransactionIT {
                                 .descriptionValues(new DescriptionValues()
                                         .description("Secretary's particulars changed;director's particulars changed"))
                                 .type("363(288)")
-                                .originalDescription("original description")
                 ));
 
         // when
@@ -868,7 +867,6 @@ class AssociatedFilingTransactionIT {
                                 .descriptionValues(new DescriptionValues()
                                         .description("Secretary's particulars changed;director's particulars changed"))
                                 .type("363(288)")
-                                .originalDescription("original description")
                 ));
 
         // when

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/AssociatedFilingChildMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/AssociatedFilingChildMapperTest.java
@@ -63,7 +63,6 @@ class AssociatedFilingChildMapperTest {
                 .entityId(ENTITY_ID)
                 .deltaAt(NEWEST_REQUEST_DELTA_AT)
                 .category("annual-return")
-                .originalDescription("original description")
                 .date(Instant.parse("2005-05-10T12:00:00.000Z"))
                 .description("legacy")
                 .descriptionValues(descriptionValues)

--- a/src/test/resources/mongo_docs/associated_filings/existing_associated_filing_doc_with_action_date_and_document_metadata.json
+++ b/src/test/resources/mongo_docs/associated_filings/existing_associated_filing_doc_with_action_date_and_document_metadata.json
@@ -13,8 +13,7 @@
         },
         "date" : "2005-05-10T12:00:00.000Z",
         "_entity_id": "<existing_child_entity_id>",
-        "delta_at": "<existing_child_delta_at>",
-        "original_description": "original description"
+        "delta_at": "<existing_child_delta_at>"
       }
     ],
     "action_date" : "2014-09-15T00:00:00.000Z",

--- a/src/test/resources/mongo_docs/associated_filings/existing_associated_filing_doc_with_no_parent.json
+++ b/src/test/resources/mongo_docs/associated_filings/existing_associated_filing_doc_with_no_parent.json
@@ -13,8 +13,7 @@
         },
         "date" : "2005-05-10T12:00:00.000Z",
         "_entity_id": "<child_entity_id>",
-        "delta_at": "<child_delta_at>",
-        "original_description": "original description"
+        "delta_at": "<child_delta_at>"
       }
     ],
     "links" : {

--- a/src/test/resources/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json
+++ b/src/test/resources/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json
@@ -12,8 +12,7 @@
         },
         "date" : "2005-05-10T12:00:00.000Z",
         "_entity_id": "<existing_child_entity_id>",
-        "delta_at": "<existing_child_delta_at>",
-        "original_description": "original description"
+        "delta_at": "<existing_child_delta_at>"
       }
     ],
     "action_date" : "2014-09-15T00:00:00.000Z",

--- a/src/test/resources/mongo_docs/associated_filings/existing_parent_doc_with_two_associated_filings.json
+++ b/src/test/resources/mongo_docs/associated_filings/existing_parent_doc_with_two_associated_filings.json
@@ -12,8 +12,7 @@
         },
         "date" : "2005-05-10T12:00:00.000Z",
         "_entity_id": "<existing_child_entity_id>",
-        "delta_at": "<existing_child_delta_at>",
-        "original_description": "original description"
+        "delta_at": "<existing_child_delta_at>"
       },
       {
         "type" : "363(288)",
@@ -24,8 +23,7 @@
         },
         "date" : "2005-05-10T12:00:00.000Z",
         "_entity_id": "<child_entity_id>",
-        "delta_at": "<child_delta_at>",
-        "original_description": "original description"
+        "delta_at": "<child_delta_at>"
       }
     ],
     "action_date" : "2014-09-15T00:00:00.000Z",

--- a/src/test/resources/mongo_docs/associated_filings/expected_associated_filing_doc_with_no_parent.json
+++ b/src/test/resources/mongo_docs/associated_filings/expected_associated_filing_doc_with_no_parent.json
@@ -13,8 +13,7 @@
         },
         "date" : "2005-05-10T12:00:00.000Z",
         "_entity_id": "<child_entity_id>",
-        "delta_at": "<child_delta_at>",
-        "original_description": "original description"
+        "delta_at": "<child_delta_at>"
       }
     ],
     "links" : {

--- a/src/test/resources/mongo_docs/associated_filings/expected_parent_doc_with_one_associated_filing.json
+++ b/src/test/resources/mongo_docs/associated_filings/expected_parent_doc_with_one_associated_filing.json
@@ -25,8 +25,7 @@
         },
         "date" : "2005-05-10T12:00:00.000Z",
         "_entity_id": "<child_entity_id>",
-        "delta_at": "<child_delta_at>",
-        "original_description": "original description"
+        "delta_at": "<child_delta_at>"
       }
     ],
     "paper_filed" : true

--- a/src/test/resources/mongo_docs/associated_filings/expected_parent_doc_with_two_associated_filings.json
+++ b/src/test/resources/mongo_docs/associated_filings/expected_parent_doc_with_two_associated_filings.json
@@ -12,8 +12,7 @@
         },
         "date" : "2005-05-10T12:00:00.000Z",
         "_entity_id": "<existing_child_entity_id>",
-        "delta_at": "<existing_child_delta_at>",
-        "original_description": "original description"
+        "delta_at": "<existing_child_delta_at>"
       },
       {
         "type" : "363(288)",
@@ -24,8 +23,7 @@
         },
         "date" : "2005-05-10T12:00:00.000Z",
         "_entity_id": "<child_entity_id>",
-        "delta_at": "<child_delta_at>",
-        "original_description": "original description"
+        "delta_at": "<child_delta_at>"
       }
     ],
     "action_date" : "2014-09-15T00:00:00.000Z",

--- a/src/test/resources/resource_changed/expected-associated-filing-resource-deleted.json
+++ b/src/test/resources/resource_changed/expected-associated-filing-resource-deleted.json
@@ -12,8 +12,7 @@
         "description_values" : {
           "description" : "Secretary's particulars changed;director's particulars changed"
         },
-        "date" : "2005-05-10",
-        "original_description": "original description"
+        "date": "2005-05-10"
       }
     ],
     "links" : {


### PR DESCRIPTION
## Describe the changes
* Updated `AssociatedFilingChildMapper` to remove updates to the `original_description`
* Updated `TopLevelTransactionMapper `to update the `original_description` when the associated filing is an embedded child within a parent delta
* Updated the unit and integration tests for associated filings
* Not extra tests were required for this bug fix as the existing test data was already well-formed

### Related Jira tickets

[DSND-2691](https://companieshouse.atlassian.net/browse/DSND-2691)

## Developer check list

### General

- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._


[DSND-2691]: https://companieshouse.atlassian.net/browse/DSND-2691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ