### PR TITLE
DSND-2826: Remove class field from Mongo documents

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/config/MongoDbConfig.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/config/MongoDbConfig.java
@@ -16,22 +16,9 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableTransactionManagement
 public class MongoDbConfig implements InitializingBean {
 
-    @Bean
-    MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
-        return new MongoTransactionManager(dbFactory);
-    }
-
-    @Bean
-    MongoTemplate mongoTemplate(MongoDatabaseFactory factory) {
-        MongoTemplate mongoTemplate = new MongoTemplate(factory);
-        mongoTemplate.setWriteConcern(WriteConcern.ACKNOWLEDGED);
-        return mongoTemplate;
-    }
-
-    @Lazy
     private final MappingMongoConverter mappingMongoConverter;
 
-    public MongoDbConfig(MappingMongoConverter mappingMongoConverter) {
+    public MongoDbConfig(@Lazy MappingMongoConverter mappingMongoConverter) {
         this.mappingMongoConverter = mappingMongoConverter;
     }
 
@@ -39,5 +26,17 @@ public class MongoDbConfig implements InitializingBean {
     @Override
     public void afterPropertiesSet() {
         mappingMongoConverter.setTypeMapper(new DefaultMongoTypeMapper(null));
+    }
+
+    @Bean
+    MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
+        return new MongoTransactionManager(dbFactory);
+    }
+
+    @Bean
+    MongoTemplate mongoTemplate(MongoDatabaseFactory factory) {
+        MongoTemplate mongoTemplate = new MongoTemplate(factory, mappingMongoConverter);
+        mongoTemplate.setWriteConcern(WriteConcern.ACKNOWLEDGED);
+        return mongoTemplate;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/config/WebSecurityConfig.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/config/WebSecurityConfig.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.filinghistory.api.config;
 
-import java.util.Arrays;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,8 +24,8 @@ public class WebSecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
-            .cors(AbstractHttpConfigurer::disable)
-            .addFilterBefore(new CustomCorsFilter(externalMethods()), CsrfFilter.class);
+                .cors(AbstractHttpConfigurer::disable)
+                .addFilterBefore(new CustomCorsFilter(externalMethods()), CsrfFilter.class);
         return http.build();
     }
 
@@ -40,6 +39,6 @@ public class WebSecurityConfig {
 
     @Bean
     public List<String> externalMethods() {
-        return Arrays.asList(HttpMethod.GET.name());
+        return List.of(HttpMethod.GET.name());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerCORSIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerCORSIT.java
@@ -1,27 +1,24 @@
 package uk.gov.companieshouse.filinghistory.api.controller;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.companieshouse.api.filinghistory.FilingHistoryList;
 import uk.gov.companieshouse.filinghistory.api.service.FilingHistoryGetResponseProcessor;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @SpringBootTest
 @AutoConfigureMockMvc
-class FilingHistoryControllerCORSTest {
+class FilingHistoryControllerCORSIT {
 
     private static final String GET_FILING_HISTORY = "/company/00006400/filing-history";
     private static final String PUT_FILING_HISTORY = "/company/00006400/filing-history/1/internal";
@@ -48,11 +45,11 @@ class FilingHistoryControllerCORSTest {
                         .options(GET_FILING_HISTORY)
                         .header("Origin", "")
                         .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isNoContent())
-            .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN))
-            .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS))
-            .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
-            .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_MAX_AGE));
+                .andExpect(status().isNoContent())
+                .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS))
+                .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
+                .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_MAX_AGE));
     }
 
     @Test
@@ -70,9 +67,9 @@ class FilingHistoryControllerCORSTest {
                         .header("ERIC-Authorised-Key-Privileges", ERIC_AUTH)
                         .header("items_per_page", 5)
                         .header("start_index", 2))
-            .andExpect(status().isOk())
-            .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
-            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, containsString("GET")));
+                .andExpect(status().isOk())
+                .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, containsString("GET")));
     }
 
     @Test
@@ -90,9 +87,9 @@ class FilingHistoryControllerCORSTest {
                         .header("ERIC-Authorised-Key-Privileges", ERIC_AUTH)
                         .header("items_per_page", 5)
                         .header("start_index", 2))
-            .andExpect(status().isForbidden())
-            .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
-            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, containsString("GET")));
+                .andExpect(status().isForbidden())
+                .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, containsString("GET")));
     }
 
     @Test
@@ -110,9 +107,8 @@ class FilingHistoryControllerCORSTest {
                         .header("ERIC-Authorised-Key-Privileges", ERIC_AUTH)
                         .header("items_per_page", 5)
                         .header("start_index", 2))
-            .andExpect(status().isForbidden())
-            .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
-            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, containsString("GET")));
+                .andExpect(status().isForbidden())
+                .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, containsString("GET")));
     }
-
 }


### PR DESCRIPTION
## Describe the changes
* Adds the configured mapping converter to the mongo template bean used by the repository to avoid persisting the _class field in Mongo documents.

### Related Jira tickets

[DSND-2826](https://companieshouse.atlassian.net/browse/DSND-2826)

## Developer check list

### General

- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._


[DSND-2826]: https://companieshouse.atlassian.net/browse/DSND-2826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ