### PR TITLE
DSND-2826: Fix updating of legacy docs

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/config/MongoDbConfig.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/config/MongoDbConfig.java
@@ -16,22 +16,9 @@ import org.springframework.transaction.annotation.EnableTransactionManagement;
 @EnableTransactionManagement
 public class MongoDbConfig implements InitializingBean {
 
-    @Bean
-    MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
-        return new MongoTransactionManager(dbFactory);
-    }
-
-    @Bean
-    MongoTemplate mongoTemplate(MongoDatabaseFactory factory) {
-        MongoTemplate mongoTemplate = new MongoTemplate(factory);
-        mongoTemplate.setWriteConcern(WriteConcern.ACKNOWLEDGED);
-        return mongoTemplate;
-    }
-
-    @Lazy
     private final MappingMongoConverter mappingMongoConverter;
 
-    public MongoDbConfig(MappingMongoConverter mappingMongoConverter) {
+    public MongoDbConfig(@Lazy MappingMongoConverter mappingMongoConverter) {
         this.mappingMongoConverter = mappingMongoConverter;
     }
 
@@ -39,5 +26,17 @@ public class MongoDbConfig implements InitializingBean {
     @Override
     public void afterPropertiesSet() {
         mappingMongoConverter.setTypeMapper(new DefaultMongoTypeMapper(null));
+    }
+
+    @Bean
+    MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
+        return new MongoTransactionManager(dbFactory);
+    }
+
+    @Bean
+    MongoTemplate mongoTemplate(MongoDatabaseFactory factory) {
+        MongoTemplate mongoTemplate = new MongoTemplate(factory, mappingMongoConverter);
+        mongoTemplate.setWriteConcern(WriteConcern.ACKNOWLEDGED);
+        return mongoTemplate;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/config/WebSecurityConfig.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/config/WebSecurityConfig.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.filinghistory.api.config;
 
-import java.util.Arrays;
 import java.util.List;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -25,8 +24,8 @@ public class WebSecurityConfig {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable)
-            .cors(AbstractHttpConfigurer::disable)
-            .addFilterBefore(new CustomCorsFilter(externalMethods()), CsrfFilter.class);
+                .cors(AbstractHttpConfigurer::disable)
+                .addFilterBefore(new CustomCorsFilter(externalMethods()), CsrfFilter.class);
         return http.build();
     }
 
@@ -40,6 +39,6 @@ public class WebSecurityConfig {
 
     @Bean
     public List<String> externalMethods() {
-        return Arrays.asList(HttpMethod.GET.name());
+        return List.of(HttpMethod.GET.name());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/model/mongo/UnversionedFilingHistoryDocument.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/model/mongo/UnversionedFilingHistoryDocument.java
@@ -205,7 +205,7 @@ public class UnversionedFilingHistoryDocument {
 
     @Override
     public String toString() {
-        return "FilingHistoryDocument{" +
+        return "UnversionedFilingHistoryDocument{" +
                 "transactionId='" + transactionId + '\'' +
                 ", version=" + version +
                 ", entityId='" + entityId + '\'' +

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/model/mongo/UnversionedFilingHistoryDocument.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/model/mongo/UnversionedFilingHistoryDocument.java
@@ -3,18 +3,16 @@ package uk.gov.companieshouse.filinghistory.api.model.mongo;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Objects;
 import org.springframework.data.annotation.Id;
-import org.springframework.data.annotation.Version;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document(collection = "company_filing_history")
-public class FilingHistoryDocument {
+public class UnversionedFilingHistoryDocument {
 
     @Id
     @JsonProperty("_id")
     private String transactionId;
-    @Version
-    private Long version;
+    private Long version = 0L;
     @Field("_entity_id")
     @JsonProperty("_entity_id")
     private String entityId;
@@ -43,11 +41,30 @@ public class FilingHistoryDocument {
     @JsonProperty("matched_default")
     private Integer matchedDefault;
 
+    public UnversionedFilingHistoryDocument() {
+    }
+
+    public UnversionedFilingHistoryDocument(FilingHistoryDocument copy) {
+        this.transactionId = copy.getTransactionId();
+        this.version = 0L;
+        this.entityId = copy.getEntityId();
+        this.companyNumber = copy.getCompanyNumber();
+        this.documentId = copy.getDocumentId();
+        this.barcode = copy.getBarcode();
+        this.data = copy.getData();
+        this.originalDescription = copy.getOriginalDescription();
+        this.originalValues = copy.getOriginalValues();
+        this.deltaAt = copy.getDeltaAt();
+        this.updated = copy.getUpdated();
+        this.created = copy.getCreated();
+        this.matchedDefault = copy.getMatchedDefault();
+    }
+
     public String getTransactionId() {
         return transactionId;
     }
 
-    public FilingHistoryDocument transactionId(String transactionId) {
+    public UnversionedFilingHistoryDocument transactionId(String transactionId) {
         this.transactionId = transactionId;
         return this;
     }
@@ -56,7 +73,7 @@ public class FilingHistoryDocument {
         return version;
     }
 
-    public FilingHistoryDocument version(long version) {
+    public UnversionedFilingHistoryDocument version(long version) {
         this.version = version;
         return this;
     }
@@ -65,7 +82,7 @@ public class FilingHistoryDocument {
         return entityId;
     }
 
-    public FilingHistoryDocument entityId(String entityId) {
+    public UnversionedFilingHistoryDocument entityId(String entityId) {
         this.entityId = entityId;
         return this;
     }
@@ -74,7 +91,7 @@ public class FilingHistoryDocument {
         return companyNumber;
     }
 
-    public FilingHistoryDocument companyNumber(String companyNumber) {
+    public UnversionedFilingHistoryDocument companyNumber(String companyNumber) {
         this.companyNumber = companyNumber;
         return this;
     }
@@ -83,7 +100,7 @@ public class FilingHistoryDocument {
         return documentId;
     }
 
-    public FilingHistoryDocument documentId(String documentId) {
+    public UnversionedFilingHistoryDocument documentId(String documentId) {
         this.documentId = documentId;
         return this;
     }
@@ -92,7 +109,7 @@ public class FilingHistoryDocument {
         return barcode;
     }
 
-    public FilingHistoryDocument barcode(String barcode) {
+    public UnversionedFilingHistoryDocument barcode(String barcode) {
         this.barcode = barcode;
         return this;
     }
@@ -101,7 +118,7 @@ public class FilingHistoryDocument {
         return data;
     }
 
-    public FilingHistoryDocument data(FilingHistoryData data) {
+    public UnversionedFilingHistoryDocument data(FilingHistoryData data) {
         this.data = data;
         return this;
     }
@@ -110,7 +127,7 @@ public class FilingHistoryDocument {
         return originalDescription;
     }
 
-    public FilingHistoryDocument originalDescription(String originalDescription) {
+    public UnversionedFilingHistoryDocument originalDescription(String originalDescription) {
         this.originalDescription = originalDescription;
         return this;
     }
@@ -119,7 +136,7 @@ public class FilingHistoryDocument {
         return originalValues;
     }
 
-    public FilingHistoryDocument originalValues(FilingHistoryOriginalValues filingHistoryOriginalValues) {
+    public UnversionedFilingHistoryDocument originalValues(FilingHistoryOriginalValues filingHistoryOriginalValues) {
         this.originalValues = filingHistoryOriginalValues;
         return this;
     }
@@ -128,7 +145,7 @@ public class FilingHistoryDocument {
         return deltaAt;
     }
 
-    public FilingHistoryDocument deltaAt(String deltaAt) {
+    public UnversionedFilingHistoryDocument deltaAt(String deltaAt) {
         this.deltaAt = deltaAt;
         return this;
     }
@@ -137,7 +154,7 @@ public class FilingHistoryDocument {
         return updated;
     }
 
-    public FilingHistoryDocument updated(FilingHistoryDeltaTimestamp updated) {
+    public UnversionedFilingHistoryDocument updated(FilingHistoryDeltaTimestamp updated) {
         this.updated = updated;
         return this;
     }
@@ -146,7 +163,7 @@ public class FilingHistoryDocument {
         return created;
     }
 
-    public FilingHistoryDocument created(FilingHistoryDeltaTimestamp created) {
+    public UnversionedFilingHistoryDocument created(FilingHistoryDeltaTimestamp created) {
         this.created = created;
         return this;
     }
@@ -155,7 +172,7 @@ public class FilingHistoryDocument {
         return matchedDefault;
     }
 
-    public FilingHistoryDocument matchedDefault(Integer matchedDefault) {
+    public UnversionedFilingHistoryDocument matchedDefault(Integer matchedDefault) {
         this.matchedDefault = matchedDefault;
         return this;
     }
@@ -168,7 +185,7 @@ public class FilingHistoryDocument {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        FilingHistoryDocument that = (FilingHistoryDocument) o;
+        UnversionedFilingHistoryDocument that = (UnversionedFilingHistoryDocument) o;
         return Objects.equals(transactionId, that.transactionId) && Objects.equals(version,
                 that.version) && Objects.equals(entityId, that.entityId) && Objects.equals(
                 companyNumber, that.companyNumber) && Objects.equals(documentId, that.documentId)

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerCORSIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerCORSIT.java
@@ -1,27 +1,24 @@
 package uk.gov.companieshouse.filinghistory.api.controller;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import uk.gov.companieshouse.api.filinghistory.FilingHistoryList;
 import uk.gov.companieshouse.filinghistory.api.service.FilingHistoryGetResponseProcessor;
 
-import static org.hamcrest.Matchers.containsString;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.springframework.http.MediaType.APPLICATION_JSON;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
 @SpringBootTest
 @AutoConfigureMockMvc
-class FilingHistoryControllerCORSTest {
+class FilingHistoryControllerCORSIT {
 
     private static final String GET_FILING_HISTORY = "/company/00006400/filing-history";
     private static final String PUT_FILING_HISTORY = "/company/00006400/filing-history/1/internal";
@@ -48,11 +45,11 @@ class FilingHistoryControllerCORSTest {
                         .options(GET_FILING_HISTORY)
                         .header("Origin", "")
                         .contentType(MediaType.APPLICATION_JSON))
-            .andExpect(status().isNoContent())
-            .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN))
-            .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS))
-            .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
-            .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_MAX_AGE));
+                .andExpect(status().isNoContent())
+                .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN))
+                .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_HEADERS))
+                .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
+                .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_MAX_AGE));
     }
 
     @Test
@@ -70,9 +67,9 @@ class FilingHistoryControllerCORSTest {
                         .header("ERIC-Authorised-Key-Privileges", ERIC_AUTH)
                         .header("items_per_page", 5)
                         .header("start_index", 2))
-            .andExpect(status().isOk())
-            .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
-            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, containsString("GET")));
+                .andExpect(status().isOk())
+                .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, containsString("GET")));
     }
 
     @Test
@@ -90,9 +87,9 @@ class FilingHistoryControllerCORSTest {
                         .header("ERIC-Authorised-Key-Privileges", ERIC_AUTH)
                         .header("items_per_page", 5)
                         .header("start_index", 2))
-            .andExpect(status().isForbidden())
-            .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
-            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, containsString("GET")));
+                .andExpect(status().isForbidden())
+                .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, containsString("GET")));
     }
 
     @Test
@@ -110,9 +107,8 @@ class FilingHistoryControllerCORSTest {
                         .header("ERIC-Authorised-Key-Privileges", ERIC_AUTH)
                         .header("items_per_page", 5)
                         .header("start_index", 2))
-            .andExpect(status().isForbidden())
-            .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
-            .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, containsString("GET")));
+                .andExpect(status().isForbidden())
+                .andExpect(header().exists(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS))
+                .andExpect(header().string(HttpHeaders.ACCESS_CONTROL_ALLOW_METHODS, containsString("GET")));
     }
-
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/repository/RepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/repository/RepositoryTest.java
@@ -26,6 +26,7 @@ import uk.gov.companieshouse.filinghistory.api.exception.BadGatewayException;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDeleteAggregate;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryListAggregate;
+import uk.gov.companieshouse.filinghistory.api.model.mongo.UnversionedFilingHistoryDocument;
 
 @ExtendWith(MockitoExtension.class)
 class RepositoryTest {
@@ -42,8 +43,6 @@ class RepositoryTest {
     @Mock
     private MongoTemplate mongoTemplate;
 
-    @Mock
-    private FilingHistoryDocument document;
     @Mock
     private AggregationResults<FilingHistoryListAggregate> aggregationResults;
     @Mock
@@ -128,12 +127,25 @@ class RepositoryTest {
     @Test
     void shouldCallSaveWithFilingHistoryDocument() {
         // given
+        FilingHistoryDocument document = new FilingHistoryDocument()
+                .version(0);
+
+        // when
+        repository.update(document);
+
+        // then
+        verify(mongoTemplate).save(document);
+    }
+
+    @Test
+    void shouldCallSaveWithUnversionedFilingHistoryDocumentWhenNullVersion() {
+        // given
 
         // when
         repository.update(new FilingHistoryDocument());
 
         // then
-        verify(mongoTemplate).save(new FilingHistoryDocument());
+        verify(mongoTemplate).save(new UnversionedFilingHistoryDocument());
     }
 
     @Test
@@ -142,12 +154,15 @@ class RepositoryTest {
         when(mongoTemplate.save(any(FilingHistoryDocument.class))).thenThrow(new DataAccessException("...") {
         });
 
+        FilingHistoryDocument document = new FilingHistoryDocument()
+                .version(0);
+
         // when
-        Executable executable = () -> repository.update(new FilingHistoryDocument());
+        Executable executable = () -> repository.update(document);
 
         // then
         assertThrows(BadGatewayException.class, executable);
-        verify(mongoTemplate).save(new FilingHistoryDocument());
+        verify(mongoTemplate).save(document);
     }
 
     @Test

--- a/src/test/resources/mongo_docs/filing-history-document.json
+++ b/src/test/resources/mongo_docs/filing-history-document.json
@@ -1,6 +1,5 @@
 {
   "_id" : "<id>",
-  "version": 0,
   "company_number" : "<company_number>",
   "data" : {
     "action_date" : ISODate("2014-08-29T00:00:00.000Z"),


### PR DESCRIPTION
## Describe the changes
* If no version exists, which is the case for legacy documents persisted by the old backend, spring versioning will not be used and the version field will be initialised so that spring versioning can be used on the following update.
* Legacy documents are updated very infrequently so there is little worry about concurrent writes causing lost updates.

### Related Jira tickets

[DSND-2826](https://companieshouse.atlassian.net/browse/DSND-2826)

## Developer check list

### General

- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._


[DSND-2826]: https://companieshouse.atlassian.net/browse/DSND-2826?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ