### PR TITLE
BI-13958: Update published_at format

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/DateUtils.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/DateUtils.java
@@ -30,6 +30,11 @@ public final class DateUtils {
                 .orElse(null);
     }
 
+    public static String publishedAtString(final Instant source) {
+        return source.atOffset(ZoneOffset.UTC)
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss"));
+    }
+
     public static boolean isDeltaStale(final String requestDeltaAt, final String existingDeltaAt) {
         return StringUtils.isNotBlank(existingDeltaAt) && !OffsetDateTime.parse(requestDeltaAt, FORMATTER)
                 .isAfter(OffsetDateTime.parse(existingDeltaAt, FORMATTER));

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ResourceChangedRequestMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ResourceChangedRequestMapper.java
@@ -5,14 +5,13 @@ import static uk.gov.companieshouse.filinghistory.api.FilingHistoryApplication.N
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.util.function.Supplier;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
 import uk.gov.companieshouse.filinghistory.api.exception.InternalServerErrorException;
 import uk.gov.companieshouse.filinghistory.api.logging.DataMapHolder;
+import uk.gov.companieshouse.filinghistory.api.mapper.DateUtils;
 import uk.gov.companieshouse.filinghistory.api.mapper.get.ItemGetResponseMapper;
 import uk.gov.companieshouse.filinghistory.api.model.ResourceChangedRequest;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument;
@@ -38,9 +37,8 @@ public class ResourceChangedRequestMapper {
 
     public ChangedResource mapChangedResource(ResourceChangedRequest request) {
         FilingHistoryDocument document = request.filingHistoryDocument();
-        ChangedResourceEvent event = new ChangedResourceEvent().publishedAt(instantSupplier.get()
-                .atOffset(ZoneOffset.UTC)
-                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")));
+        ChangedResourceEvent event = new ChangedResourceEvent().publishedAt(
+                DateUtils.publishedAtString(instantSupplier.get()));
         ChangedResource changedResource = new ChangedResource()
                 .resourceUri("/company/%s/filing-history/%s".formatted(document.getCompanyNumber(),
                         document.getTransactionId()))

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ResourceChangedRequestMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ResourceChangedRequestMapper.java
@@ -5,6 +5,8 @@ import static uk.gov.companieshouse.filinghistory.api.FilingHistoryApplication.N
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.util.function.Supplier;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
@@ -36,7 +38,9 @@ public class ResourceChangedRequestMapper {
 
     public ChangedResource mapChangedResource(ResourceChangedRequest request) {
         FilingHistoryDocument document = request.filingHistoryDocument();
-        ChangedResourceEvent event = new ChangedResourceEvent().publishedAt(instantSupplier.get().toString());
+        ChangedResourceEvent event = new ChangedResourceEvent().publishedAt(instantSupplier.get()
+                .atOffset(ZoneOffset.UTC)
+                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")));
         ChangedResource changedResource = new ChangedResource()
                 .resourceUri("/company/%s/filing-history/%s".formatted(document.getCompanyNumber(),
                         document.getTransactionId()))

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AnnotationTransactionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AnnotationTransactionIT.java
@@ -23,6 +23,8 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.function.Supplier;
@@ -1527,14 +1529,16 @@ class AnnotationTransactionIT {
                 .deletedData(null)
                 .event(new ChangedResourceEvent()
                         .fieldsChanged(null)
-                        .publishedAt(UPDATED_AT.toString())
+                        .publishedAt(UPDATED_AT.atOffset(ZoneOffset.UTC)
+                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")))
                         .type("changed")));
     }
 
     private static String getExpectedResourceDeleted(String filename) throws IOException {
         return IOUtils.resourceToString(filename,
                         StandardCharsets.UTF_8)
-                .replaceAll("<published_at>", UPDATED_AT.toString())
+                .replaceAll("<published_at>", UPDATED_AT.atOffset(ZoneOffset.UTC)
+                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")))
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<company_number>", COMPANY_NUMBER)
                 .replaceAll("<updated_at>", EXISTING_DATE)

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AnnotationTransactionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AnnotationTransactionIT.java
@@ -23,8 +23,6 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.function.Supplier;
@@ -54,6 +52,7 @@ import uk.gov.companieshouse.api.filinghistory.ExternalData.CategoryEnum;
 import uk.gov.companieshouse.api.filinghistory.FilingHistoryList;
 import uk.gov.companieshouse.api.filinghistory.FilingHistoryList.FilingHistoryStatusEnum;
 import uk.gov.companieshouse.api.filinghistory.Links;
+import uk.gov.companieshouse.filinghistory.api.mapper.DateUtils;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryAnnotation;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument;
 
@@ -79,6 +78,7 @@ class AnnotationTransactionIT {
     private static final String STALE_REQUEST_DELTA_AT = "20130615185208001000";
     private static final String EXISTING_DELTA_AT = "20140815230459600643";
     private static final Instant UPDATED_AT = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+    private static final String PUBLISHED_AT = DateUtils.publishedAtString(UPDATED_AT);
     private static final String CONTEXT_ID = "ABCD1234";
     private static final String RESOURCE_CHANGED_URI = "/private/resource-changed";
     private static final String EXISTING_DATE = "2012-06-08T11:57:11Z";
@@ -1529,16 +1529,14 @@ class AnnotationTransactionIT {
                 .deletedData(null)
                 .event(new ChangedResourceEvent()
                         .fieldsChanged(null)
-                        .publishedAt(UPDATED_AT.atOffset(ZoneOffset.UTC)
-                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")))
+                        .publishedAt(PUBLISHED_AT)
                         .type("changed")));
     }
 
     private static String getExpectedResourceDeleted(String filename) throws IOException {
         return IOUtils.resourceToString(filename,
                         StandardCharsets.UTF_8)
-                .replaceAll("<published_at>", UPDATED_AT.atOffset(ZoneOffset.UTC)
-                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")))
+                .replaceAll("<published_at>", PUBLISHED_AT)
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<company_number>", COMPANY_NUMBER)
                 .replaceAll("<updated_at>", EXISTING_DATE)

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AssociatedFilingTransactionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AssociatedFilingTransactionIT.java
@@ -23,6 +23,8 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.function.Supplier;
@@ -1209,14 +1211,16 @@ class AssociatedFilingTransactionIT {
                 .deletedData(null)
                 .event(new ChangedResourceEvent()
                         .fieldsChanged(null)
-                        .publishedAt(UPDATED_AT.toString())
+                        .publishedAt(UPDATED_AT.atOffset(ZoneOffset.UTC)
+                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")))
                         .type("changed")));
     }
 
     private static String getExpectedResourceDeleted() throws IOException {
         return IOUtils.resourceToString("/resource_changed/expected-associated-filing-resource-deleted.json",
                         StandardCharsets.UTF_8)
-                .replaceAll("<published_at>", UPDATED_AT.toString())
+                .replaceAll("<published_at>", UPDATED_AT.atOffset(ZoneOffset.UTC)
+                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")))
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<company_number>", COMPANY_NUMBER)
                 .replaceAll("<updated_at>", EXISTING_DATE)

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AssociatedFilingTransactionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AssociatedFilingTransactionIT.java
@@ -23,8 +23,6 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.function.Supplier;
@@ -54,6 +52,7 @@ import uk.gov.companieshouse.api.filinghistory.ExternalData.CategoryEnum;
 import uk.gov.companieshouse.api.filinghistory.FilingHistoryList;
 import uk.gov.companieshouse.api.filinghistory.FilingHistoryList.FilingHistoryStatusEnum;
 import uk.gov.companieshouse.api.filinghistory.Links;
+import uk.gov.companieshouse.filinghistory.api.mapper.DateUtils;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryAssociatedFiling;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument;
 
@@ -79,6 +78,7 @@ class AssociatedFilingTransactionIT {
     private static final String STALE_REQUEST_DELTA_AT = "20130615185208001000";
     private static final String EXISTING_DELTA_AT = "20140815230459600643";
     private static final Instant UPDATED_AT = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+    private static final String PUBLISHED_AT = DateUtils.publishedAtString(UPDATED_AT);
     private static final String CONTEXT_ID = "ABCD1234";
     private static final String RESOURCE_CHANGED_URI = "/private/resource-changed";
     private static final String EXISTING_DATE = "2012-06-08T11:57:11Z";
@@ -1211,16 +1211,14 @@ class AssociatedFilingTransactionIT {
                 .deletedData(null)
                 .event(new ChangedResourceEvent()
                         .fieldsChanged(null)
-                        .publishedAt(UPDATED_AT.atOffset(ZoneOffset.UTC)
-                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")))
+                        .publishedAt(PUBLISHED_AT)
                         .type("changed")));
     }
 
     private static String getExpectedResourceDeleted() throws IOException {
         return IOUtils.resourceToString("/resource_changed/expected-associated-filing-resource-deleted.json",
                         StandardCharsets.UTF_8)
-                .replaceAll("<published_at>", UPDATED_AT.atOffset(ZoneOffset.UTC)
-                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")))
+                .replaceAll("<published_at>", PUBLISHED_AT)
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<company_number>", COMPANY_NUMBER)
                 .replaceAll("<updated_at>", EXISTING_DATE)

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerIT.java
@@ -22,6 +22,8 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.function.Supplier;
@@ -1396,12 +1398,14 @@ class FilingHistoryControllerIT {
 
     private static String getExpectedChangedResource() throws IOException {
         return IOUtils.resourceToString("/resource_changed/expected-resource-changed.json", StandardCharsets.UTF_8)
-                .replaceAll("<published_at>", UPDATED_AT.toString());
+                .replaceAll("<published_at>", UPDATED_AT.atOffset(ZoneOffset.UTC)
+                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")));
     }
 
     private static String getExpectedChangedResourceDelete() throws IOException {
         return IOUtils.resourceToString("/resource_changed/expected-resource-deleted.json",
                         StandardCharsets.UTF_8)
-                .replaceAll("<published_at>", UPDATED_AT.toString());
+                .replaceAll("<published_at>", UPDATED_AT.atOffset(ZoneOffset.UTC)
+                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerIT.java
@@ -22,8 +22,6 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.function.Supplier;
@@ -56,6 +54,7 @@ import uk.gov.companieshouse.api.filinghistory.InternalData.TransactionKindEnum;
 import uk.gov.companieshouse.api.filinghistory.InternalDataOriginalValues;
 import uk.gov.companieshouse.api.filinghistory.InternalFilingHistoryApi;
 import uk.gov.companieshouse.api.filinghistory.Links;
+import uk.gov.companieshouse.filinghistory.api.mapper.DateUtils;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryAnnotation;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryData;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDeltaTimestamp;
@@ -86,6 +85,7 @@ class FilingHistoryControllerIT {
     private static final String STALE_REQUEST_DELTA_AT = "20130615185208001000";
     private static final String EXISTING_DELTA_AT = "20140815230459600643";
     private static final Instant UPDATED_AT = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+    private static final String PUBLISHED_AT = DateUtils.publishedAtString(UPDATED_AT);
     private static final String UPDATED_BY = "5419d856b6a59f32b7684d0e";
     private static final String TM01_TYPE = "TM01";
     private static final String DATE = "2014-09-15T23:21:18.000Z";
@@ -1398,14 +1398,12 @@ class FilingHistoryControllerIT {
 
     private static String getExpectedChangedResource() throws IOException {
         return IOUtils.resourceToString("/resource_changed/expected-resource-changed.json", StandardCharsets.UTF_8)
-                .replaceAll("<published_at>", UPDATED_AT.atOffset(ZoneOffset.UTC)
-                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")));
+                .replaceAll("<published_at>", PUBLISHED_AT);
     }
 
     private static String getExpectedChangedResourceDelete() throws IOException {
         return IOUtils.resourceToString("/resource_changed/expected-resource-deleted.json",
                         StandardCharsets.UTF_8)
-                .replaceAll("<published_at>", UPDATED_AT.atOffset(ZoneOffset.UTC)
-                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")));
+                .replaceAll("<published_at>", PUBLISHED_AT);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/ResolutionTransactionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/ResolutionTransactionIT.java
@@ -23,6 +23,8 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.function.Supplier;
@@ -1657,14 +1659,16 @@ class ResolutionTransactionIT {
                 .deletedData(null)
                 .event(new ChangedResourceEvent()
                         .fieldsChanged(null)
-                        .publishedAt(UPDATED_AT.toString())
+                        .publishedAt(UPDATED_AT.atOffset(ZoneOffset.UTC)
+                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")))
                         .type("changed")));
     }
 
     private static String getExpectedResourceDeleted(String filename) throws IOException {
         return IOUtils.resourceToString(filename,
                         StandardCharsets.UTF_8)
-                .replaceAll("<published_at>", UPDATED_AT.toString())
+                .replaceAll("<published_at>", UPDATED_AT.atOffset(ZoneOffset.UTC)
+                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")))
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<company_number>", COMPANY_NUMBER)
                 .replaceAll("<first_resolution_delta_at>", EXISTING_DELTA_AT)

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/ResolutionTransactionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/ResolutionTransactionIT.java
@@ -23,8 +23,6 @@ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.function.Supplier;
@@ -56,6 +54,7 @@ import uk.gov.companieshouse.api.filinghistory.FilingHistoryList.FilingHistorySt
 import uk.gov.companieshouse.api.filinghistory.Links;
 import uk.gov.companieshouse.api.filinghistory.Resolution;
 import uk.gov.companieshouse.api.filinghistory.Resolution.CategoryEnum;
+import uk.gov.companieshouse.filinghistory.api.mapper.DateUtils;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryResolution;
 
@@ -84,6 +83,7 @@ class ResolutionTransactionIT {
     private static final String NEWEST_REQUEST_DELTA_AT = "20140916230459600643";
     private static final String STALE_REQUEST_DELTA_AT = "20130615185208001000";
     private static final Instant UPDATED_AT = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+    private static final String PUBLISHED_AT = DateUtils.publishedAtString(UPDATED_AT);
     private static final Instant CREATED_AT = Instant.parse("2014-09-15T23:21:18.000Z");
     private static final String RESOURCE_CHANGED_URI = "/private/resource-changed";
     private static final String EXISTING_DATE = "2012-06-08T11:57:11Z";
@@ -1659,16 +1659,14 @@ class ResolutionTransactionIT {
                 .deletedData(null)
                 .event(new ChangedResourceEvent()
                         .fieldsChanged(null)
-                        .publishedAt(UPDATED_AT.atOffset(ZoneOffset.UTC)
-                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")))
+                        .publishedAt(PUBLISHED_AT)
                         .type("changed")));
     }
 
     private static String getExpectedResourceDeleted(String filename) throws IOException {
         return IOUtils.resourceToString(filename,
                         StandardCharsets.UTF_8)
-                .replaceAll("<published_at>", UPDATED_AT.atOffset(ZoneOffset.UTC)
-                        .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss")))
+                .replaceAll("<published_at>", PUBLISHED_AT)
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<company_number>", COMPANY_NUMBER)
                 .replaceAll("<first_resolution_delta_at>", EXISTING_DELTA_AT)

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ResourceChangedRequestMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ResourceChangedRequestMapperTest.java
@@ -13,6 +13,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.function.Supplier;
@@ -79,7 +81,8 @@ class ResourceChangedRequestMapperTest {
                 .event(new ChangedResourceEvent()
                         .type(CHANGED_EVENT_TYPE)
                         .fieldsChanged(fieldsChanged)
-                        .publishedAt(UPDATED_AT.toString()));
+                        .publishedAt(UPDATED_AT.atOffset(ZoneOffset.UTC)
+                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss"))));
 
         // when
         ChangedResource actual = mapper.mapChangedResource(upsertResourceChangedRequest);
@@ -103,7 +106,8 @@ class ResourceChangedRequestMapperTest {
                 .resourceKind(FILING_HISTORY)
                 .event(new ChangedResourceEvent()
                         .type(CHANGED_EVENT_TYPE)
-                        .publishedAt(UPDATED_AT.toString()));
+                        .publishedAt(UPDATED_AT.atOffset(ZoneOffset.UTC)
+                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss"))));
 
         // when
         ChangedResource actual = mapper.mapChangedResource(upsertResourceChangedRequest);
@@ -136,7 +140,8 @@ class ResourceChangedRequestMapperTest {
                 .deletedData(deletedDataAsObject)
                 .event(new ChangedResourceEvent()
                         .type(DELETED_EVENT_TYPE)
-                        .publishedAt(UPDATED_AT.toString()));
+                        .publishedAt(UPDATED_AT.atOffset(ZoneOffset.UTC)
+                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss"))));
 
         // when
         ChangedResource actual = mapper.mapChangedResource(deleteResourceChangedRequest);

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ResourceChangedRequestMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ResourceChangedRequestMapperTest.java
@@ -13,8 +13,6 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.function.Supplier;
@@ -30,6 +28,7 @@ import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
 import uk.gov.companieshouse.api.filinghistory.ExternalData;
 import uk.gov.companieshouse.filinghistory.api.exception.InternalServerErrorException;
 import uk.gov.companieshouse.filinghistory.api.logging.DataMapHolder;
+import uk.gov.companieshouse.filinghistory.api.mapper.DateUtils;
 import uk.gov.companieshouse.filinghistory.api.mapper.get.ItemGetResponseMapper;
 import uk.gov.companieshouse.filinghistory.api.model.ResourceChangedRequest;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument;
@@ -38,6 +37,7 @@ import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument
 class ResourceChangedRequestMapperTest {
 
     private static final Instant UPDATED_AT = Instant.now().truncatedTo(ChronoUnit.MILLIS);
+    private static final String PUBLISHED_AT = DateUtils.publishedAtString(UPDATED_AT);
     private static final String FILING_HISTORY = "filing-history";
     private static final String EXPECTED_CONTEXT_ID = "35234234";
     private static final ExternalData deletedData = new ExternalData();
@@ -81,8 +81,7 @@ class ResourceChangedRequestMapperTest {
                 .event(new ChangedResourceEvent()
                         .type(CHANGED_EVENT_TYPE)
                         .fieldsChanged(fieldsChanged)
-                        .publishedAt(UPDATED_AT.atOffset(ZoneOffset.UTC)
-                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss"))));
+                        .publishedAt(PUBLISHED_AT));
 
         // when
         ChangedResource actual = mapper.mapChangedResource(upsertResourceChangedRequest);
@@ -106,8 +105,7 @@ class ResourceChangedRequestMapperTest {
                 .resourceKind(FILING_HISTORY)
                 .event(new ChangedResourceEvent()
                         .type(CHANGED_EVENT_TYPE)
-                        .publishedAt(UPDATED_AT.atOffset(ZoneOffset.UTC)
-                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss"))));
+                        .publishedAt(PUBLISHED_AT));
 
         // when
         ChangedResource actual = mapper.mapChangedResource(upsertResourceChangedRequest);
@@ -140,8 +138,7 @@ class ResourceChangedRequestMapperTest {
                 .deletedData(deletedDataAsObject)
                 .event(new ChangedResourceEvent()
                         .type(DELETED_EVENT_TYPE)
-                        .publishedAt(UPDATED_AT.atOffset(ZoneOffset.UTC)
-                                .format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'hh:mm:ss"))));
+                        .publishedAt(PUBLISHED_AT));
 
         // when
         ChangedResource actual = mapper.mapChangedResource(deleteResourceChangedRequest);


### PR DESCRIPTION
* Modify timestamp in ResourceChangeRequestMapper to round to two decimal places
* Update various tests to the same as above

## Describe the changes

Update published_at timestamp to be in UTC format and rounded to two decimal places.

### Related Jira tickets

[BI-13958](https://companieshouse.atlassian.net/browse/BI-13958)

## Developer check list

### General

- [x] Is the PR as small as it can be?
- [x] Has the Jira ticket been updated with any relevant comments?
- [x] Is the `README` up to date?
- [x] Has the `POM` been updated for the latest versions of dependencies?
- [x] Has the code been double-checked against `main`?
- [x] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [x] Do the code changes have unit and integration tests with code coverage > 80%?
- [x] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [x] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [x] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [x] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._


[BI-13958]: https://companieshouse.atlassian.net/browse/BI-13958?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ