### PR TITLE
BI-14082: Allow doc metadata PATCH to create links object when null

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,18 +18,18 @@
   <properties>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <spring.boot.version>3.3.3</spring.boot.version>
-    <jib-maven-plugin.version>3.4.2</jib-maven-plugin.version>
-    <structured-logging.version>3.0.14</structured-logging.version>
-    <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
-    <api-security-java.version>2.0.5</api-security-java.version>
-    <private-api-sdk-java.version>4.0.133</private-api-sdk-java.version>
-    <maven-surefire-plugin.version>3.4.0</maven-surefire-plugin.version>
-    <maven-build-helper-plugin.version>3.5.0</maven-build-helper-plugin.version>
-    <maven-failsafe-plugin.version>3.4.0</maven-failsafe-plugin.version>
+    <spring.boot.version>3.3.4</spring.boot.version>
+    <jib-maven-plugin.version>3.4.3</jib-maven-plugin.version>
+    <structured-logging.version>3.0.20</structured-logging.version>
+    <api-sdk-manager-java-library.version>3.0.6</api-sdk-manager-java-library.version>
+    <api-security-java.version>2.0.8</api-security-java.version>
+    <private-api-sdk-java.version>4.0.221</private-api-sdk-java.version>
+    <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
+    <maven-build-helper-plugin.version>3.6.0</maven-build-helper-plugin.version>
+    <maven-failsafe-plugin.version>3.5.1</maven-failsafe-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <test-containers.version>1.20.1</test-containers.version>
-    <wiremock.version>3.9.1</wiremock.version>
+    <test-containers.version>1.20.3</test-containers.version>
+    <wiremock.version>3.9.2</wiremock.version>
 
     <skip.unit.tests>false</skip.unit.tests>
     <skip.integration.tests>false</skip.integration.tests>
@@ -70,6 +70,12 @@
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
       <version>${json-path.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.xmlunit</groupId>
+      <artifactId>xmlunit-core</artifactId>
+      <version>2.10.0</version>
+      <scope>test</scope>
     </dependency>
     <!--end transitive dependencies-->
 

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/AbstractTransactionMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/AbstractTransactionMapper.java
@@ -1,15 +1,22 @@
 package uk.gov.companieshouse.filinghistory.api.mapper.upsert;
 
 import static java.lang.Boolean.TRUE;
+import static uk.gov.companieshouse.filinghistory.api.FilingHistoryApplication.NAMESPACE;
 
 import java.time.Instant;
 import uk.gov.companieshouse.api.filinghistory.FilingHistoryDocumentMetadataUpdateApi;
 import uk.gov.companieshouse.api.filinghistory.InternalFilingHistoryApi;
+import uk.gov.companieshouse.filinghistory.api.logging.DataMapHolder;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryData;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDeltaTimestamp;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument;
+import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryLinks;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
 
 public abstract class AbstractTransactionMapper {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(NAMESPACE);
 
     private final LinksMapper linksMapper;
 
@@ -44,9 +51,21 @@ public abstract class AbstractTransactionMapper {
     }
 
     public FilingHistoryDocument mapDocumentMetadata(FilingHistoryDocumentMetadataUpdateApi request,
-                                                     FilingHistoryDocument existingDocument) {
+            FilingHistoryDocument existingDocument) {
 
-        existingDocument.getData().getLinks().documentMetadata(request.getDocumentMetadata());
+        FilingHistoryLinks existingLinks = existingDocument.getData().getLinks();
+        if (existingLinks == null) {
+            LOGGER.info("Existing legacy data with null links object - creating new links object",
+                    DataMapHolder.getLogMap());
+
+            existingDocument.getData().links(new FilingHistoryLinks()
+                    .self("/company/%s/filing-history/%s"
+                            .formatted(existingDocument.getCompanyNumber(), existingDocument.getTransactionId()))
+                    .documentMetadata(request.getDocumentMetadata()));
+        } else {
+            existingLinks.documentMetadata(request.getDocumentMetadata());
+        }
+
         if (request.getPages() > 0) {
             existingDocument.getData().pages(request.getPages());
         }

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/service/FilingHistoryService.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/service/FilingHistoryService.java
@@ -1,27 +1,20 @@
 package uk.gov.companieshouse.filinghistory.api.service;
 
-import static uk.gov.companieshouse.filinghistory.api.FilingHistoryApplication.NAMESPACE;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import uk.gov.companieshouse.filinghistory.api.client.ResourceChangedApiClient;
-import uk.gov.companieshouse.filinghistory.api.exception.BadGatewayException;
-import uk.gov.companieshouse.filinghistory.api.logging.DataMapHolder;
 import uk.gov.companieshouse.filinghistory.api.model.ResourceChangedRequest;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDeleteAggregate;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryListAggregate;
 import uk.gov.companieshouse.filinghistory.api.repository.Repository;
-import uk.gov.companieshouse.logging.Logger;
-import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Component
 public class FilingHistoryService implements Service {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(NAMESPACE);
     private final ResourceChangedApiClient apiClient;
     private final Repository repository;
 
@@ -91,10 +84,5 @@ public class FilingHistoryService implements Service {
     public void deleteExistingFilingHistory(FilingHistoryDocument existingDocument) {
         repository.deleteById(existingDocument.getTransactionId());
         apiClient.callResourceChanged(new ResourceChangedRequest(existingDocument, true, null));
-    }
-
-    private void throwBadGatewayException(final int statusCode) {
-        LOGGER.info("Resource changed endpoint responded with: %s".formatted(statusCode), DataMapHolder.getLogMap());
-        throw new BadGatewayException("Error calling resource changed endpoint");
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/TopLevelTransactionMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/TopLevelTransactionMapperTest.java
@@ -287,6 +287,33 @@ class TopLevelTransactionMapperTest {
         assertEquals(DOC_METADATA_LINK, actualDocument.getData().getLinks().getDocumentMetadata());
     }
 
+    @Test
+    void mapDocumentMetadataShouldReturnUpdatedFilingHistoryDocumentWhenExistingDocumentLinksObjectIsNull() {
+        // given
+        final FilingHistoryDocumentMetadataUpdateApi request = buildPatchDocMetadataRequestBody();
+
+        final FilingHistoryDocument existingDocument = getFilingHistoryDocument(
+                new FilingHistoryData()
+                        .links(null),
+                existingFilingHistoryOriginalValues,
+                EXISTING_DOCUMENT_DELTA_AT);
+
+        final FilingHistoryDocument expectedDocument = getFilingHistoryDocument(
+                new FilingHistoryData()
+                        .links(new FilingHistoryLinks()
+                                .self("/company/%s/filing-history/%s".formatted(COMPANY_NUMBER, TRANSACTION_ID))
+                                .documentMetadata(DOC_METADATA_LINK))
+                        .pages(5),
+                existingFilingHistoryOriginalValues,
+                EXISTING_DOCUMENT_DELTA_AT);
+
+        // when
+        FilingHistoryDocument actualDocument = topLevelMapper.mapDocumentMetadata(request, existingDocument);
+
+        // then
+        assertEquals(expectedDocument, actualDocument);
+    }
+
     private InternalFilingHistoryApi buildPutRequestBody(String deltaAt) {
         return new InternalFilingHistoryApi()
                 .externalData(requestExternalData)
@@ -311,7 +338,7 @@ class TopLevelTransactionMapperTest {
     }
 
     private FilingHistoryDocument getFilingHistoryDocument(FilingHistoryData data,
-                                                           FilingHistoryOriginalValues originalValues, String deltaAt) {
+            FilingHistoryOriginalValues originalValues, String deltaAt) {
         FilingHistoryDeltaTimestamp timestamp = new FilingHistoryDeltaTimestamp()
                 .at(INSTANT)
                 .by(UPDATED_BY);

--- a/src/test/resources/mongo_docs/filing-history-document-no-document-metadata.json
+++ b/src/test/resources/mongo_docs/filing-history-document-no-document-metadata.json
@@ -1,0 +1,51 @@
+{
+  "_id" : "<id>",
+  "company_number" : "<company_number>",
+  "data" : {
+    "action_date" : ISODate("2014-08-29T00:00:00.000Z"),
+    "category" : "<category>",
+    "type" : "TM01",
+    "description" : "termination-director-company-with-name-termination-date",
+    "subcategory" : "termination",
+    "date" : ISODate("2014-09-15T23:21:18.000Z"),
+    "description_values" : {
+      "termination_date" : ISODate("2014-08-29T00:00:00.000Z"),
+      "officer_name" : "John Tester"
+    },
+    "annotations":[
+      {
+        "annotation" : "Clarification This document was second filed with the CH04 registered on 26/11/2011",
+        "category" : "annotation",
+        "date" : "2011-11-26T11:27:55.000Z",
+        "description" : "annotation",
+        "description_values" : {
+          "description" : "Clarification This document was second filed with the CH04 registered on 26/11/2011"
+        },
+        "type" : "ANNOTATION",
+        "_entity_id": "2234567890",
+        "delta_at": "20140815230459600643"
+      }
+    ],
+    "links" : {
+      "self" : "/company/<company_number>/filing-history/<id>"
+    },
+    "pages" : NumberInt(1)
+  },
+  "_barcode" : "X4BI89B6",
+  "delta_at" : "20140815230459600643",
+  "_entity_id" : "<entity_id>",
+  "updated": {
+    "at": ISODate("2014-09-17T18:52:08.001Z"),
+    "by": "5419d856b6a59f32b7684d0e"
+  },
+  "created": {
+    "at": ISODate("2014-09-14T18:52:08.001Z"),
+    "by": "5419d856b6a59f32b7684dE4"
+  },
+  "original_values" : {
+    "officer_name" : "John Tester",
+    "resignation_date" : "29/08/2014"
+  },
+  "original_description" : "Appointment Terminated, Director john tester",
+  "_document_id" : "000X4BI89B65846"
+}

--- a/src/test/resources/mongo_docs/filing-history-document-null-links.json
+++ b/src/test/resources/mongo_docs/filing-history-document-null-links.json
@@ -1,0 +1,48 @@
+{
+  "_id" : "<id>",
+  "company_number" : "<company_number>",
+  "data" : {
+    "action_date" : ISODate("2014-08-29T00:00:00.000Z"),
+    "category" : "<category>",
+    "type" : "TM01",
+    "description" : "termination-director-company-with-name-termination-date",
+    "subcategory" : "termination",
+    "date" : ISODate("2014-09-15T23:21:18.000Z"),
+    "description_values" : {
+      "termination_date" : ISODate("2014-08-29T00:00:00.000Z"),
+      "officer_name" : "John Tester"
+    },
+    "annotations":[
+      {
+        "annotation" : "Clarification This document was second filed with the CH04 registered on 26/11/2011",
+        "category" : "annotation",
+        "date" : "2011-11-26T11:27:55.000Z",
+        "description" : "annotation",
+        "description_values" : {
+          "description" : "Clarification This document was second filed with the CH04 registered on 26/11/2011"
+        },
+        "type" : "ANNOTATION",
+        "_entity_id": "2234567890",
+        "delta_at": "20140815230459600643"
+      }
+    ],
+    "pages" : NumberInt(1)
+  },
+  "_barcode" : "X4BI89B6",
+  "delta_at" : "20140815230459600643",
+  "_entity_id" : "<entity_id>",
+  "updated": {
+    "at": ISODate("2014-09-17T18:52:08.001Z"),
+    "by": "5419d856b6a59f32b7684d0e"
+  },
+  "created": {
+    "at": ISODate("2014-09-14T18:52:08.001Z"),
+    "by": "5419d856b6a59f32b7684dE4"
+  },
+  "original_values" : {
+    "officer_name" : "John Tester",
+    "resignation_date" : "29/08/2014"
+  },
+  "original_description" : "Appointment Terminated, Director john tester",
+  "_document_id" : "000X4BI89B65846"
+}

--- a/src/test/resources/resource_changed/expected-resource-changed-document-metadata.json
+++ b/src/test/resources/resource_changed/expected-resource-changed-document-metadata.json
@@ -1,0 +1,10 @@
+{
+  "resource_kind": "filing-history",
+  "resource_uri": "/company/12345678/filing-history/transactionId",
+  "context_id": "ABCD1234",
+  "event": {
+    "fields_changed": ["links.document_metadata"],
+    "published_at": "<published_at>",
+    "type": "changed"
+  }
+}


### PR DESCRIPTION
## Describe the changes
This PR fixes an issue where legacy data did not have a links object on the mongo document. The fix now allows for this by creating a new links object if it is null on the existing mongo document.

### Related Jira tickets

[BI-14082](https://companieshouse.atlassian.net/browse/BI-14082)

## Developer check list

### General

- [x] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [x] Has the `POM` been updated for the latest versions of dependencies?
- [x] Has the code been double-checked against `main`?
- [x] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._


[BI-14082]: https://companieshouse.atlassian.net/browse/BI-14082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ