### PR TITLE
DSND-3112: Revert wiremock version to 3.9.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
   <name>filing-history-data-api</name>
 
   <artifactId>filing-history-data-api</artifactId>
-  <version>latest</version>
+  <version>unversioned</version>
   <packaging>jar</packaging>
 
   <properties>
@@ -29,7 +29,7 @@
     <maven-failsafe-plugin.version>3.5.1</maven-failsafe-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <test-containers.version>1.20.3</test-containers.version>
-    <wiremock.version>3.9.2</wiremock.version>
+    <wiremock.version>3.9.1</wiremock.version>
 
     <skip.unit.tests>false</skip.unit.tests>
     <skip.integration.tests>false</skip.integration.tests>
@@ -236,7 +236,7 @@
           <from>
             <image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-corretto-runtime-21:latest</image>
           </from>
-          <to>
+          <to>c
             <image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/filing-history-data-api:latest</image>
           </to>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -236,7 +236,7 @@
           <from>
             <image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/ci-corretto-runtime-21:latest</image>
           </from>
-          <to>c
+          <to>
             <image>416670754337.dkr.ecr.eu-west-2.amazonaws.com/filing-history-data-api:latest</image>
           </to>
         </configuration>


### PR DESCRIPTION
* Update pom to revert changes for Concourse

## Describe the changes

### Related Jira tickets

[DSND-3112](https://companieshouse.atlassian.net/browse/DSND-3112)

## Developer check list

### General

- [x] Is the PR as small as it can be?
- [x] Has the Jira ticket been updated with any relevant comments?
- [x] Is the `README` up to date?
- [x] Has the `POM` been updated for the latest versions of dependencies?
- [x] Has the code been double-checked against `main`?
- [x] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [x] Do the code changes have unit and integration tests with code coverage > 80%?
- [x] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [x] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._


[DSND-3112]: https://companieshouse.atlassian.net/browse/DSND-3112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ