### PR TITLE
DSND-3112: Revert pom changes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,7 @@
   <properties>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <!-- bumped down from 3.3.5 to ensure the passes works on Concourse -->
-    <spring.boot.version>3.3.4</spring.boot.version>
+    <spring.boot.version>3.3.5</spring.boot.version>
     <jib-maven-plugin.version>3.4.2</jib-maven-plugin.version> <!-- Version 3.4.3 does not work -->
     <structured-logging.version>3.0.20</structured-logging.version>
     <api-sdk-manager-java-library.version>3.0.6</api-sdk-manager-java-library.version>
@@ -27,11 +26,9 @@
     <private-api-sdk-java.version>4.0.224</private-api-sdk-java.version>
     <maven-surefire-plugin.version>3.5.1</maven-surefire-plugin.version>
     <maven-build-helper-plugin.version>3.6.0</maven-build-helper-plugin.version>
-    <!-- bumped down from 3.5.1 to ensure the build passes on Concourse -->
-    <maven-failsafe-plugin.version>3.4.0</maven-failsafe-plugin.version>
+    <maven-failsafe-plugin.version>3.5.1</maven-failsafe-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
-    <!-- bumped down from 1.20.3 to ensure the build passes on Concourse -->
-    <test-containers.version>1.20.1</test-containers.version>
+    <test-containers.version>1.20.3</test-containers.version>
     <wiremock.version>3.9.2</wiremock.version>
 
     <skip.unit.tests>false</skip.unit.tests>


### PR DESCRIPTION
* Pom changes were made to diagnose an issue with testcontainers not running on concourse. This issue was actually due to the ci-pipeline file missing a section, so we can revert the pom changes previously made.

## Describe the changes

### Related Jira tickets

[DSND-3112](https://companieshouse.atlassian.net/browse/DSND-3112)

## Developer check list

### General

- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._
