### PR TITLE
DSND-3112: Send resource changed when child missing but parent not

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/ChildDeleteMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/ChildDeleteMapper.java
@@ -21,6 +21,7 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Component
 public class ChildDeleteMapper {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(FilingHistoryApplication.NAMESPACE);
 
     private final Supplier<Instant> instantSupplier;

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/CompositeResolutionDeleteMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/CompositeResolutionDeleteMapper.java
@@ -18,6 +18,7 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Component
 public class CompositeResolutionDeleteMapper {
+
     private static final Logger LOGGER = LoggerFactory.getLogger(FilingHistoryApplication.NAMESPACE);
 
     private final Supplier<Instant> instantSupplier;

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/service/FilingHistoryService.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/service/FilingHistoryService.java
@@ -100,11 +100,19 @@ public class FilingHistoryService implements Service {
     }
 
     @Override
-    public void callResourceChangedForAbsentDeletedData(String companyNumber, String transactionId) {
+    public void callResourceChangedAbsentParent(String companyNumber, String transactionId) {
         apiClient.callResourceChanged(ResourceChangedRequest.builder()
                 .companyNumber(companyNumber)
                 .transactionId(transactionId)
                 .isDelete(true)
+                .build());
+    }
+
+    @Override
+    public void callResourceChangedAbsentChild(String companyNumber, String transactionId) {
+        apiClient.callResourceChanged(ResourceChangedRequest.builder()
+                .companyNumber(companyNumber)
+                .transactionId(transactionId)
                 .build());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/service/Service.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/service/Service.java
@@ -15,13 +15,15 @@ public interface Service {
 
     Optional<FilingHistoryDeleteAggregate> findFilingHistoryByEntityId(String entityId);
 
-    void insertFilingHistory(final FilingHistoryDocument docToInsert, String companyNumber, String transactionId);
+    void insertFilingHistory(FilingHistoryDocument docToInsert, String companyNumber, String transactionId);
 
-    void updateFilingHistory(final FilingHistoryDocument docToUpdate, String companyNumber, String transactionId);
+    void updateFilingHistory(FilingHistoryDocument docToUpdate, String companyNumber, String transactionId);
 
-    void updateDocumentMetadata(final FilingHistoryDocument docToUpdate, String companyNumber, String transactionId);
+    void updateDocumentMetadata(FilingHistoryDocument docToUpdate, String companyNumber, String transactionId);
 
     void deleteExistingFilingHistory(FilingHistoryDocument existingDocument, String companyNumber, String transactionId);
 
-    void callResourceChangedForAbsentDeletedData(String companyNumber, String transactionId);
+    void callResourceChangedAbsentParent(String companyNumber, String transactionId);
+
+    void callResourceChangedAbsentChild(String companyNumber, String transactionId);
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/client/ResourceChangedApiClientAspectFeatureDisabledIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/client/ResourceChangedApiClientAspectFeatureDisabledIT.java
@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.filinghistory.api.mapper.upsert.ResourceChangedRequestMapper;
@@ -21,9 +21,9 @@ class ResourceChangedApiClientAspectFeatureDisabledIT {
 
     @Autowired
     private ResourceChangedApiClient client;
-    @MockBean
+    @MockitoBean
     private Supplier<InternalApiClient> apiClientSupplier;
-    @MockBean
+    @MockitoBean
     private ResourceChangedRequestMapper mapper;
     @Mock
     private ResourceChangedRequest resourceChangedRequest;

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/client/ResourceChangedApiClientAspectFeatureEnabledIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/client/ResourceChangedApiClientAspectFeatureEnabledIT.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.companieshouse.api.InternalApiClient;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
@@ -27,9 +27,9 @@ class ResourceChangedApiClientAspectFeatureEnabledIT {
 
     @Autowired
     private ResourceChangedApiClient client;
-    @MockBean
+    @MockitoBean
     private Supplier<InternalApiClient> apiClientSupplier;
-    @MockBean
+    @MockitoBean
     private ResourceChangedRequestMapper mapper;
     @Mock
     private InternalApiClient internalApiClient;

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AnnotationTransactionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AnnotationTransactionIT.java
@@ -30,11 +30,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -94,7 +94,7 @@ class AnnotationTransactionIT {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private Supplier<Instant> instantSupplier;
 
     @DynamicPropertySource

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AssociatedFilingTransactionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AssociatedFilingTransactionIT.java
@@ -30,11 +30,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -93,7 +93,7 @@ class AssociatedFilingTransactionIT {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private Supplier<Instant> instantSupplier;
 
     @DynamicPropertySource
@@ -111,7 +111,8 @@ class AssociatedFilingTransactionIT {
     void shouldAddAssociatedFilingToExistingDocumentAndReturn200OK() throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/existing_parent_doc_with_zero_associated_filings.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/existing_parent_doc_with_zero_associated_filings.json",
+                StandardCharsets.UTF_8);
         existingDocumentJson = existingDocumentJson
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<company_number>", COMPANY_NUMBER)
@@ -124,7 +125,8 @@ class AssociatedFilingTransactionIT {
         mongoTemplate.insert(existingDocument, FILING_HISTORY_COLLECTION);
 
         String expectedDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/expected_parent_doc_with_one_associated_filing.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/expected_parent_doc_with_one_associated_filing.json",
+                StandardCharsets.UTF_8);
         expectedDocumentJson = expectedDocumentJson
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<company_number>", COMPANY_NUMBER)
@@ -170,14 +172,16 @@ class AssociatedFilingTransactionIT {
         assertEquals(expectedDocument, actualDocument);
 
         verify(instantSupplier, times(2)).get();
-        WireMock.verify(requestMadeFor(new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResource())));
+        WireMock.verify(
+                requestMadeFor(new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResource())));
     }
 
     @Test
     void shouldAddAssociatedFilingToExistingAssociatedFilingListAndReturn200OK() throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json",
+                StandardCharsets.UTF_8);
         existingDocumentJson = existingDocumentJson
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<company_number>", COMPANY_NUMBER)
@@ -192,7 +196,8 @@ class AssociatedFilingTransactionIT {
         mongoTemplate.insert(existingDocument, FILING_HISTORY_COLLECTION);
 
         String expectedDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/expected_parent_doc_with_two_associated_filings.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/expected_parent_doc_with_two_associated_filings.json",
+                StandardCharsets.UTF_8);
         expectedDocumentJson = expectedDocumentJson
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<company_number>", COMPANY_NUMBER)
@@ -240,14 +245,16 @@ class AssociatedFilingTransactionIT {
         assertEquals(expectedDocument, actualDocument);
 
         verify(instantSupplier, times(2)).get();
-        WireMock.verify(requestMadeFor(new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResource())));
+        WireMock.verify(
+                requestMadeFor(new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResource())));
     }
 
     @Test
     void shouldInsertNoParentAssociatedFilingDocumentAndReturn200OK() throws Exception {
         // given
         String expectedDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/expected_associated_filing_doc_with_no_parent.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/expected_associated_filing_doc_with_no_parent.json",
+                StandardCharsets.UTF_8);
         expectedDocumentJson = expectedDocumentJson
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<updated_at>", UPDATED_AT.toString())
@@ -293,14 +300,16 @@ class AssociatedFilingTransactionIT {
         assertEquals(expectedDocument, actualDocument);
 
         verify(instantSupplier, times(2)).get();
-        WireMock.verify(requestMadeFor(new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResource())));
+        WireMock.verify(
+                requestMadeFor(new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResource())));
     }
 
     @Test
     void shouldUpdateNoParentDocumentWithParentFieldsAndNotChangeAssociatedFilingAndReturn200OK() throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/existing_associated_filing_doc_with_no_parent.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/existing_associated_filing_doc_with_no_parent.json",
+                StandardCharsets.UTF_8);
         existingDocumentJson = existingDocumentJson
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<company_number>", COMPANY_NUMBER)
@@ -315,7 +324,8 @@ class AssociatedFilingTransactionIT {
         mongoTemplate.insert(existingDocument, FILING_HISTORY_COLLECTION);
 
         String expectedDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/expected_parent_doc_with_one_associated_filing.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/expected_parent_doc_with_one_associated_filing.json",
+                StandardCharsets.UTF_8);
         expectedDocumentJson = expectedDocumentJson
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<updated_at>", UPDATED_AT.toString())
@@ -365,14 +375,16 @@ class AssociatedFilingTransactionIT {
         assertEquals(expectedDocument, actualDocument);
 
         verify(instantSupplier, times(2)).get();
-        WireMock.verify(requestMadeFor(new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResource())));
+        WireMock.verify(
+                requestMadeFor(new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResource())));
     }
 
     @Test
     void shouldUpdateExistingAssociatedFilingAndReturn200OK() throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json",
+                StandardCharsets.UTF_8);
         existingDocumentJson = existingDocumentJson
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<barcode>", BARCODE)
@@ -388,7 +400,8 @@ class AssociatedFilingTransactionIT {
         mongoTemplate.insert(existingDocument, FILING_HISTORY_COLLECTION);
 
         String expectedDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/expected_parent_doc_with_one_associated_filing.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/expected_parent_doc_with_one_associated_filing.json",
+                StandardCharsets.UTF_8);
         expectedDocumentJson = expectedDocumentJson
                 .replaceAll("<barcode>", BARCODE)
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
@@ -435,14 +448,16 @@ class AssociatedFilingTransactionIT {
         assertEquals(expectedDocument, actualDocument);
 
         verify(instantSupplier, times(2)).get();
-        WireMock.verify(requestMadeFor(new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResource())));
+        WireMock.verify(
+                requestMadeFor(new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResource())));
     }
 
     @Test
     void shouldUpdateParentDocumentAndNotChangeAssociatedFilingAndReturn200OK() throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json",
+                StandardCharsets.UTF_8);
         existingDocumentJson = existingDocumentJson
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<barcode>", BARCODE)
@@ -458,7 +473,8 @@ class AssociatedFilingTransactionIT {
         mongoTemplate.insert(existingDocument, FILING_HISTORY_COLLECTION);
 
         String expectedDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/expected_parent_doc_with_one_associated_filing.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/expected_parent_doc_with_one_associated_filing.json",
+                StandardCharsets.UTF_8);
         expectedDocumentJson = expectedDocumentJson
                 .replaceAll("<barcode>", BARCODE)
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
@@ -507,14 +523,17 @@ class AssociatedFilingTransactionIT {
         assertEquals(expectedDocument, actualDocument);
 
         verify(instantSupplier, times(2)).get();
-        WireMock.verify(requestMadeFor(new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResource())));
+        WireMock.verify(
+                requestMadeFor(new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResource())));
     }
 
     @Test
-    void shouldThrowConflictExceptionWhenUpdatingChildAssociatedFilingWithStaleDeltaAtAndReturn409Conflict() throws Exception {
+    void shouldThrowConflictExceptionWhenUpdatingChildAssociatedFilingWithStaleDeltaAtAndReturn409Conflict()
+            throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json",
+                StandardCharsets.UTF_8);
         existingDocumentJson = existingDocumentJson
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<barcode>", BARCODE)
@@ -563,7 +582,8 @@ class AssociatedFilingTransactionIT {
     void shouldSuccessfullyReturnSingleGetResponse() throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/existing_associated_filing_doc_with_action_date_and_document_metadata.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/existing_associated_filing_doc_with_action_date_and_document_metadata.json",
+                StandardCharsets.UTF_8);
         existingDocumentJson = existingDocumentJson
                 .replaceAll("<barcode>", "")
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
@@ -610,7 +630,8 @@ class AssociatedFilingTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID));
 
         // then
-        ExternalData actualResponse = objectMapper.readValue(result.andReturn().getResponse().getContentAsString(), ExternalData.class);
+        ExternalData actualResponse = objectMapper.readValue(result.andReturn().getResponse().getContentAsString(),
+                ExternalData.class);
 
         assertEquals(expectedResponse, actualResponse);
     }
@@ -619,7 +640,8 @@ class AssociatedFilingTransactionIT {
     void shouldReturnListGetResponseWithNoOriginalDescriptionFieldOnChildObject() throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json",
+                StandardCharsets.UTF_8);
         existingDocumentJson = existingDocumentJson
                 .replaceAll("<barcode>", "")
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
@@ -654,7 +676,8 @@ class AssociatedFilingTransactionIT {
                                         .date("2005-05-10")
                                         .description("legacy")
                                         .descriptionValues(new DescriptionValues()
-                                                .description("Secretary's particulars changed;director's particulars changed"))
+                                                .description(
+                                                        "Secretary's particulars changed;director's particulars changed"))
                                         .type("363(288)")
                         ))
                 ))
@@ -670,7 +693,8 @@ class AssociatedFilingTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID));
 
         // then
-        FilingHistoryList actualResponse = objectMapper.readValue(result.andReturn().getResponse().getContentAsString(), FilingHistoryList.class);
+        FilingHistoryList actualResponse = objectMapper.readValue(result.andReturn().getResponse().getContentAsString(),
+                FilingHistoryList.class);
 
         assertEquals(expectedResponse, actualResponse);
     }
@@ -679,7 +703,8 @@ class AssociatedFilingTransactionIT {
     void shouldUpdateExistingAssociatedFilingWhenChildHasNoDeltaAt() throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json",
+                StandardCharsets.UTF_8);
         existingDocumentJson = existingDocumentJson
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<barcode>", BARCODE)
@@ -698,7 +723,8 @@ class AssociatedFilingTransactionIT {
         mongoTemplate.insert(existingDocument, FILING_HISTORY_COLLECTION);
 
         String expectedDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/expected_parent_doc_with_one_associated_filing.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/expected_parent_doc_with_one_associated_filing.json",
+                StandardCharsets.UTF_8);
         expectedDocumentJson = expectedDocumentJson
                 .replaceAll("<barcode>", BARCODE)
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
@@ -745,14 +771,16 @@ class AssociatedFilingTransactionIT {
         assertEquals(expectedDocument, actualDocument);
 
         verify(instantSupplier, times(2)).get();
-        WireMock.verify(requestMadeFor(new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResource())));
+        WireMock.verify(
+                requestMadeFor(new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResource())));
     }
 
     @Test
     void shouldAddChildToListWhenExistingListContainsChildWithNoEntityId() throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json",
+                StandardCharsets.UTF_8);
         existingDocumentJson = existingDocumentJson
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<barcode>", BARCODE)
@@ -771,7 +799,8 @@ class AssociatedFilingTransactionIT {
         mongoTemplate.insert(existingDocument, FILING_HISTORY_COLLECTION);
 
         String expectedDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/expected_parent_doc_with_two_associated_filings.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/expected_parent_doc_with_two_associated_filings.json",
+                StandardCharsets.UTF_8);
         expectedDocumentJson = expectedDocumentJson
                 .replaceAll("<barcode>", BARCODE)
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
@@ -822,14 +851,16 @@ class AssociatedFilingTransactionIT {
         assertEquals(expectedDocument, actualDocument);
 
         verify(instantSupplier, times(2)).get();
-        WireMock.verify(requestMadeFor(new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResource())));
+        WireMock.verify(
+                requestMadeFor(new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResource())));
     }
 
     @Test
     void shouldSuccessfullyHandleSingleGetWhenDealingWithLegacyData() throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json",
+                StandardCharsets.UTF_8);
         existingDocumentJson = existingDocumentJson
                 .replaceAll("<barcode>", "")
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
@@ -843,7 +874,8 @@ class AssociatedFilingTransactionIT {
         final FilingHistoryDocument existingDocument =
                 objectMapper.readValue(existingDocumentJson, FilingHistoryDocument.class);
 
-        FilingHistoryAssociatedFiling firstAssociatedFiling = existingDocument.getData().getAssociatedFilings().getFirst();
+        FilingHistoryAssociatedFiling firstAssociatedFiling = existingDocument.getData().getAssociatedFilings()
+                .getFirst();
         firstAssociatedFiling.deltaAt(null);
         firstAssociatedFiling.entityId(null);
 
@@ -879,7 +911,8 @@ class AssociatedFilingTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID));
 
         // then
-        ExternalData actualResponse = objectMapper.readValue(result.andReturn().getResponse().getContentAsString(), ExternalData.class);
+        ExternalData actualResponse = objectMapper.readValue(result.andReturn().getResponse().getContentAsString(),
+                ExternalData.class);
 
         assertEquals(expectedResponse, actualResponse);
     }
@@ -888,7 +921,8 @@ class AssociatedFilingTransactionIT {
     void shouldSuccessfullyHandleListGetWhenDealingWithLegacyData() throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json",
+                StandardCharsets.UTF_8);
         existingDocumentJson = existingDocumentJson
                 .replaceAll("<barcode>", "")
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
@@ -902,7 +936,8 @@ class AssociatedFilingTransactionIT {
         final FilingHistoryDocument existingDocument =
                 objectMapper.readValue(existingDocumentJson, FilingHistoryDocument.class);
 
-        FilingHistoryAssociatedFiling firstAssociatedFiling = existingDocument.getData().getAssociatedFilings().getFirst();
+        FilingHistoryAssociatedFiling firstAssociatedFiling = existingDocument.getData().getAssociatedFilings()
+                .getFirst();
         firstAssociatedFiling.deltaAt(null);
         firstAssociatedFiling.entityId(null);
 
@@ -928,7 +963,8 @@ class AssociatedFilingTransactionIT {
                                         .date("2005-05-10")
                                         .description("legacy")
                                         .descriptionValues(new DescriptionValues()
-                                                .description("Secretary's particulars changed;director's particulars changed"))
+                                                .description(
+                                                        "Secretary's particulars changed;director's particulars changed"))
                                         .type("363(288)")
                         ))))
                 .itemsPerPage(25)
@@ -953,7 +989,8 @@ class AssociatedFilingTransactionIT {
     void shouldDeleteSingularAssociatedFilingFromParentWithTwoAssociatedFilings() throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/existing_parent_doc_with_two_associated_filings.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/existing_parent_doc_with_two_associated_filings.json",
+                StandardCharsets.UTF_8);
         existingDocumentJson = existingDocumentJson
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<company_number>", COMPANY_NUMBER)
@@ -971,7 +1008,8 @@ class AssociatedFilingTransactionIT {
         mongoTemplate.insert(existingDocument, FILING_HISTORY_COLLECTION);
 
         String expectedDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/expected_parent_doc_with_one_associated_filing.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/expected_parent_doc_with_one_associated_filing.json",
+                StandardCharsets.UTF_8);
         expectedDocumentJson = expectedDocumentJson
                 .replaceAll("<barcode>", BARCODE)
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
@@ -1017,7 +1055,8 @@ class AssociatedFilingTransactionIT {
     void shouldNotDeleteSingularAssociatedFilingFromParentWhenDeltaStaleAndReturn409() throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/existing_parent_doc_with_two_associated_filings.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/existing_parent_doc_with_two_associated_filings.json",
+                StandardCharsets.UTF_8);
         existingDocumentJson = existingDocumentJson
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<company_number>", COMPANY_NUMBER)
@@ -1056,7 +1095,8 @@ class AssociatedFilingTransactionIT {
     void shouldDeleteLastAssociatedFilingAndArrayFromParent() throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/existing_parent_doc_with_associated_filing.json",
+                StandardCharsets.UTF_8);
         existingDocumentJson = existingDocumentJson
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<barcode>", BARCODE)
@@ -1072,7 +1112,8 @@ class AssociatedFilingTransactionIT {
         mongoTemplate.insert(existingDocument, FILING_HISTORY_COLLECTION);
 
         String expectedDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/expected_parent_doc_with_zero_associated_filings.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/expected_parent_doc_with_zero_associated_filings.json",
+                StandardCharsets.UTF_8);
         expectedDocumentJson = expectedDocumentJson
                 .replaceAll("<barcode>", BARCODE)
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
@@ -1115,7 +1156,8 @@ class AssociatedFilingTransactionIT {
     void shouldDeleteWholeDocumentForNoParentAssociatedFiling() throws Exception {
         // given
         String existingDocumentJson = IOUtils.resourceToString(
-                "/mongo_docs/associated_filings/existing_associated_filing_doc_with_no_parent.json", StandardCharsets.UTF_8);
+                "/mongo_docs/associated_filings/existing_associated_filing_doc_with_no_parent.json",
+                StandardCharsets.UTF_8);
         existingDocumentJson = existingDocumentJson
                 .replaceAll("<transaction_id>", TRANSACTION_ID)
                 .replaceAll("<company_number>", COMPANY_NUMBER)

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerCORSIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerCORSIT.java
@@ -8,9 +8,9 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import uk.gov.companieshouse.api.filinghistory.FilingHistoryList;
@@ -32,10 +32,10 @@ class FilingHistoryControllerCORSIT {
     @Autowired
     private MockMvc mockMvc;
 
-    @MockBean
+    @MockitoBean
     private FilingHistoryList getListResponseBody;
 
-    @MockBean
+    @MockitoBean
     private FilingHistoryGetResponseProcessor getResponseProcessor;
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerMongoUnavailableIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerMongoUnavailableIT.java
@@ -22,11 +22,11 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -84,9 +84,9 @@ class FilingHistoryControllerMongoUnavailableIT {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private Supplier<Instant> instantSupplier;
-    @MockBean
+    @MockitoBean
     private Repository repository;
 
     @DynamicPropertySource
@@ -164,7 +164,8 @@ class FilingHistoryControllerMongoUnavailableIT {
     @Test
     void shouldReturn502WhenRepositoryThrowsBadGatewayDuringFindFilingHistory() throws Exception {
         // given
-        when(repository.findCompanyFilingHistoryIds(any(), anyInt(), anyInt(), any())).thenThrow(BadGatewayException.class);
+        when(repository.findCompanyFilingHistoryIds(any(), anyInt(), anyInt(), any())).thenThrow(
+                BadGatewayException.class);
 
         // when
         ResultActions result = mockMvc.perform(get(GET_FILING_HISTORY_URI, COMPANY_NUMBER,

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/ResolutionTransactionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/ResolutionTransactionIT.java
@@ -32,11 +32,11 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -100,7 +100,7 @@ class ResolutionTransactionIT {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private Supplier<Instant> instantSupplier;
 
     @DynamicPropertySource
@@ -406,7 +406,8 @@ class ResolutionTransactionIT {
 
         FilingHistoryDocument expectedDocument =
                 objectMapper.readValue(expectedDocumentJson, FilingHistoryDocument.class);
-        expectedDocument.version(existingDocument.getVersion() + 1); // This is a shared doc between insert and update operations
+        expectedDocument.version(
+                existingDocument.getVersion() + 1); // This is a shared doc between insert and update operations
 
         String requestBody = IOUtils.resourceToString(
                 "/put_requests/resolutions/put_request_body_resolution.json", StandardCharsets.UTF_8);
@@ -656,7 +657,8 @@ class ResolutionTransactionIT {
 
         FilingHistoryDocument expectedDocument =
                 objectMapper.readValue(expectedDocumentJson, FilingHistoryDocument.class);
-        expectedDocument.version(existingDocument.getVersion() + 1); // This is a shared doc between insert and update operations
+        expectedDocument.version(
+                existingDocument.getVersion() + 1); // This is a shared doc between insert and update operations
 
         String requestBody = IOUtils.resourceToString(
                 "/put_requests/resolutions/put_request_body_resolution.json", StandardCharsets.UTF_8);
@@ -1357,7 +1359,8 @@ class ResolutionTransactionIT {
         result.andExpect(MockMvcResultMatchers.status().isConflict());
 
         FilingHistoryDocument actualDocument = mongoTemplate.findById(TRANSACTION_ID, FilingHistoryDocument.class);
-        assertEquals(existingDocument, actualDocument);;
+        assertEquals(existingDocument, actualDocument);
+        ;
         assertEquals(NEWEST_REQUEST_DELTA_AT, actualDocument.getData().getResolutions().get(1).getDeltaAt());
     }
 

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/logging/RequestLoggingFilterIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/logging/RequestLoggingFilterIT.java
@@ -12,8 +12,8 @@ import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.companieshouse.api.filinghistory.DescriptionValues;
 import uk.gov.companieshouse.api.filinghistory.ExternalData;
@@ -51,7 +51,7 @@ class RequestLoggingFilterIT {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private FilingHistoryUpsertProcessor upsertProcessor;
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/CompositeResolutionDeleteMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/CompositeResolutionDeleteMapperTest.java
@@ -28,6 +28,7 @@ import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryResoluti
 
 @ExtendWith(MockitoExtension.class)
 class CompositeResolutionDeleteMapperTest {
+
     private static final Instant INSTANT = Instant.now();
     private static final String ENTITY_ID = "entity ID";
     private static final String DELTA_AT = "20151025185208001000";

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorAspectFeatureDisabledIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorAspectFeatureDisabledIT.java
@@ -9,9 +9,9 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.function.Executable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.companieshouse.filinghistory.api.exception.BadRequestException;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryData;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDeleteAggregate;
@@ -26,7 +26,7 @@ class DeleteMapperDelegatorAspectFeatureDisabledIT {
 
     @Autowired
     private DeleteMapperDelegator deleteMapperDelegator;
-    @MockBean
+    @MockitoBean
     private CompositeResolutionDeleteMapper compositeResolutionDeleteMapper;
 
     @DynamicPropertySource
@@ -58,7 +58,7 @@ class DeleteMapperDelegatorAspectFeatureDisabledIT {
                 new FilingHistoryDeleteAggregate()
                         .document(new FilingHistoryDocument()
                                 .entityId(ENTITY_ID))
-                        .resolutionIndex(0),  DELTA_AT);
+                        .resolutionIndex(0), DELTA_AT);
 
         // then
         assertThrows(BadRequestException.class, actual);

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorAspectFeatureEnabledIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/DeleteMapperDelegatorAspectFeatureEnabledIT.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryData;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDeleteAggregate;
 import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument;
@@ -26,7 +26,7 @@ class DeleteMapperDelegatorAspectFeatureEnabledIT {
 
     @Autowired
     private DeleteMapperDelegator deleteMapperDelegator;
-    @MockBean
+    @MockitoBean
     private CompositeResolutionDeleteMapper compositeResolutionDeleteMapper;
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/service/FilingHistoryDeleteProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/service/FilingHistoryDeleteProcessorTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
@@ -23,13 +24,12 @@ import uk.gov.companieshouse.filinghistory.api.model.mongo.FilingHistoryDocument
 
 @ExtendWith(MockitoExtension.class)
 class FilingHistoryDeleteProcessorTest {
+
     private static final String COMPANY_NUMBER = "12345678";
     private static final String TRANSACTION_ID = "transactionId";
     private static final String ENTITY_ID = "entity_id";
     private static final String DELTA_AT = "20151025185208001000";
     private static final String STALE_DELTA_AT = "20141025185208001000";
-    private static final FilingHistoryDeleteRequest DELETE_REQUEST =
-            new FilingHistoryDeleteRequest(COMPANY_NUMBER, TRANSACTION_ID, ENTITY_ID, DELTA_AT);
 
     @InjectMocks
     private FilingHistoryDeleteProcessor filingHistoryDeleteProcessor;
@@ -46,14 +46,15 @@ class FilingHistoryDeleteProcessorTest {
     private FilingHistoryDocument updatedDocument;
 
     @Test
-    void shouldCallDeleteWhenParentDocumentRemoved() {
+    void shouldCallDeleteWhenDocumentFoundAndDelegatorReturnsEmpty() {
         // given
         when(filingHistoryService.findFilingHistoryByEntityId(any())).thenReturn(Optional.of(deleteAggregate));
         when(deleteMapperDelegator.delegateDelete(any(), any(), any())).thenReturn(Optional.empty());
         when(deleteAggregate.getDocument()).thenReturn(existingDocument);
 
         // when
-        filingHistoryDeleteProcessor.processFilingHistoryDelete(DELETE_REQUEST);
+        filingHistoryDeleteProcessor.processFilingHistoryDelete(
+                new FilingHistoryDeleteRequest(COMPANY_NUMBER, TRANSACTION_ID, ENTITY_ID, DELTA_AT));
 
         // then
         verify(filingHistoryService).findFilingHistoryByEntityId(ENTITY_ID);
@@ -62,13 +63,14 @@ class FilingHistoryDeleteProcessorTest {
     }
 
     @Test
-    void shouldCallUpdateWhenResolutionRemovedFromComposite() {
+    void shouldCallUpdateWhenDocumentFoundAndDelegatorReturnsUpdatedDocument() {
         // given
         when(filingHistoryService.findFilingHistoryByEntityId(any())).thenReturn(Optional.of(deleteAggregate));
         when(deleteMapperDelegator.delegateDelete(any(), any(), any())).thenReturn(Optional.of(updatedDocument));
 
         // when
-        filingHistoryDeleteProcessor.processFilingHistoryDelete(DELETE_REQUEST);
+        filingHistoryDeleteProcessor.processFilingHistoryDelete(
+                new FilingHistoryDeleteRequest(COMPANY_NUMBER, TRANSACTION_ID, ENTITY_ID, DELTA_AT));
 
         // then
         verify(filingHistoryService).findFilingHistoryByEntityId(ENTITY_ID);
@@ -77,23 +79,40 @@ class FilingHistoryDeleteProcessorTest {
     }
 
     @Test
-    void deleteShouldCallResourceChangedWhenDocumentDoesNotExist() {
+    void shouldCallResourceChangedWhenChildNotFoundButParentExists() {
+        // given
+        when(filingHistoryService.findFilingHistoryByEntityId(any())).thenReturn(Optional.empty());
+        when(filingHistoryService.findExistingFilingHistory(any(), any())).thenReturn(Optional.of(existingDocument));
+
+        // when
+        filingHistoryDeleteProcessor.processFilingHistoryDelete(
+                new FilingHistoryDeleteRequest(COMPANY_NUMBER, TRANSACTION_ID, ENTITY_ID, DELTA_AT));
+
+        // then
+        verify(filingHistoryService).findFilingHistoryByEntityId(ENTITY_ID);
+        verifyNoInteractions(deleteMapperDelegator);
+        verify(filingHistoryService).findExistingFilingHistory(TRANSACTION_ID, COMPANY_NUMBER);
+        verify(filingHistoryService).callResourceChangedAbsentChild(COMPANY_NUMBER, TRANSACTION_ID);
+    }
+
+    @Test
+    void shouldCallResourceChangedWhenParentNorChildExists() {
         // given
         when(filingHistoryService.findFilingHistoryByEntityId(any())).thenReturn(Optional.empty());
 
         // when
-        filingHistoryDeleteProcessor.processFilingHistoryDelete(DELETE_REQUEST);
+        filingHistoryDeleteProcessor.processFilingHistoryDelete(
+                new FilingHistoryDeleteRequest(COMPANY_NUMBER, TRANSACTION_ID, ENTITY_ID, DELTA_AT));
 
         // then
         verify(filingHistoryService).findFilingHistoryByEntityId(ENTITY_ID);
-        verify(filingHistoryService).callResourceChangedForAbsentDeletedData(COMPANY_NUMBER, TRANSACTION_ID);
+        verifyNoInteractions(deleteMapperDelegator);
+        verify(filingHistoryService).findExistingFilingHistory(TRANSACTION_ID, COMPANY_NUMBER);
+        verify(filingHistoryService).callResourceChangedAbsentParent(COMPANY_NUMBER, TRANSACTION_ID);
     }
 
     @Test
     void shouldThrowConflictExceptionWhenDeltaAtStale() {
-        FilingHistoryDeleteRequest staleDeltaRequest =
-                new FilingHistoryDeleteRequest(COMPANY_NUMBER, TRANSACTION_ID, ENTITY_ID, STALE_DELTA_AT);
-
         // given
         when(filingHistoryService.findFilingHistoryByEntityId(any())).thenReturn(Optional.of(deleteAggregate));
         when(deleteMapperDelegator.delegateDelete(any(), any(), any())).thenReturn(Optional.empty());
@@ -101,28 +120,27 @@ class FilingHistoryDeleteProcessorTest {
         when(existingDocument.getDeltaAt()).thenReturn(DELTA_AT);
 
         // when
-        Executable executable = () -> filingHistoryDeleteProcessor.processFilingHistoryDelete(staleDeltaRequest);
+        Executable executable = () -> filingHistoryDeleteProcessor.processFilingHistoryDelete(
+                new FilingHistoryDeleteRequest(COMPANY_NUMBER, TRANSACTION_ID, ENTITY_ID, STALE_DELTA_AT));
 
         // then
         assertThrows(ConflictException.class, executable);
         verify(filingHistoryService).findFilingHistoryByEntityId(ENTITY_ID);
         verify(deleteMapperDelegator).delegateDelete(ENTITY_ID, deleteAggregate, STALE_DELTA_AT);
+        verifyNoMoreInteractions(filingHistoryService);
     }
 
     @Test
     void shouldThrowBadRequestExceptionWhenDeltaAtIsMissing() {
-        FilingHistoryDeleteRequest missingDeltaAtRequest =
-                new FilingHistoryDeleteRequest(COMPANY_NUMBER, TRANSACTION_ID, ENTITY_ID, null);
-
         // given
-
         // when
-        Executable executable = () -> filingHistoryDeleteProcessor.processFilingHistoryDelete(missingDeltaAtRequest);
+        Executable executable = () -> filingHistoryDeleteProcessor.processFilingHistoryDelete(
+                new FilingHistoryDeleteRequest(COMPANY_NUMBER, TRANSACTION_ID, ENTITY_ID, null));
 
         // then
         BadRequestException exception = assertThrows(BadRequestException.class, executable);
         assertEquals("deltaAt is null or empty", exception.getMessage());
-        verifyNoInteractions(deleteMapperDelegator);
         verifyNoInteractions(filingHistoryService);
+        verifyNoInteractions(deleteMapperDelegator);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/service/FilingHistoryServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/service/FilingHistoryServiceTest.java
@@ -253,7 +253,7 @@ class FilingHistoryServiceTest {
         when(resourceChangedApiClient.callResourceChanged(any())).thenReturn(response);
 
         // when
-        service.callResourceChangedForAbsentDeletedData(COMPANY_NUMBER, TRANSACTION_ID);
+        service.callResourceChangedAbsentParent(COMPANY_NUMBER, TRANSACTION_ID);
 
         // then
         verify(resourceChangedApiClient).callResourceChanged(any());

--- a/src/test/resources/resource_changed/expected-resource-deleted-absent-data.json
+++ b/src/test/resources/resource_changed/expected-resource-deleted-absent-data.json
@@ -1,0 +1,9 @@
+{
+  "resource_kind": "filing-history",
+  "resource_uri": "/company/12345678/filing-history/transactionId",
+  "context_id": "ABCD1234",
+  "event": {
+    "published_at": "<published_at>",
+    "type": "deleted"
+  }
+}


### PR DESCRIPTION
## Describe the changes
* Send a resource changed event when processing a delete delta and the child to delete is missing but the parent is not
* Also replaces deprecated @MockBean with @MockitoBean

### Related Jira tickets

[DSND-3112](https://companieshouse.atlassian.net/browse/DSND-3112)

## Developer check list

### General

- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._


[DSND-3112]: https://companieshouse.atlassian.net/browse/DSND-3112?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ