### PR TITLE
DSND-3241: Stop stream events for child delete with no mongo doc

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryController.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryController.java
@@ -104,7 +104,9 @@ public class FilingHistoryController {
     public ResponseEntity<Void> deleteFilingHistoryTransaction(
             @PathVariable("company_number") final String companyNumber,
             @PathVariable("transaction_id") final String transactionId,
-            @RequestHeader("X-DELTA-AT") String deltaAt, @RequestHeader("X-ENTITY-ID") String entityId) {
+            @RequestHeader("X-DELTA-AT") final String deltaAt,
+            @RequestHeader("X-ENTITY-ID") final String entityId,
+            @RequestHeader("X-PARENT-ENTITY-ID") final String parentEntityId) {
 
         DataMapHolder.get()
                 .companyNumber(companyNumber)
@@ -112,8 +114,15 @@ public class FilingHistoryController {
                 .transactionId(transactionId);
         LOGGER.info("Processing transaction delete", DataMapHolder.getLogMap());
 
-        serviceDeleteProcessor.processFilingHistoryDelete(new FilingHistoryDeleteRequest(companyNumber, transactionId,
-                entityId, deltaAt));
+        FilingHistoryDeleteRequest request = FilingHistoryDeleteRequest.builder()
+                .companyNumber(companyNumber)
+                .transactionId(transactionId)
+                .entityId(entityId)
+                .deltaAt(deltaAt)
+                .parentEntityId(parentEntityId)
+                .build();
+
+        serviceDeleteProcessor.processFilingHistoryDelete(request);
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/model/FilingHistoryDeleteRequest.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/model/FilingHistoryDeleteRequest.java
@@ -1,5 +1,47 @@
 package uk.gov.companieshouse.filinghistory.api.model;
 
-public record FilingHistoryDeleteRequest (String companyNumber, String transactionId, String entityId, String deltaAt) {
+public record FilingHistoryDeleteRequest(String companyNumber, String transactionId, String entityId, String deltaAt,
+                                         String parentEntityId) {
 
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private String companyNumber;
+        private String transactionId;
+        private String entityId;
+        private String deltaAt;
+        private String parentEntityId;
+
+        public Builder companyNumber(String companyNumber) {
+            this.companyNumber = companyNumber;
+            return this;
+        }
+
+        public Builder transactionId(String transactionId) {
+            this.transactionId = transactionId;
+            return this;
+        }
+
+        public Builder entityId(String entityId) {
+            this.entityId = entityId;
+            return this;
+        }
+
+        public Builder deltaAt(String deltaAt) {
+            this.deltaAt = deltaAt;
+            return this;
+        }
+
+        public Builder parentEntityId(String parentEntityId) {
+            this.parentEntityId = parentEntityId;
+            return this;
+        }
+
+        public FilingHistoryDeleteRequest build() {
+            return new FilingHistoryDeleteRequest(companyNumber, transactionId, entityId, deltaAt, parentEntityId);
+        }
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/service/FilingHistoryDeleteProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/service/FilingHistoryDeleteProcessor.java
@@ -60,8 +60,14 @@ public class FilingHistoryDeleteProcessor implements DeleteProcessor {
                                                     companyNumber, transactionId);
                                         }),
                         () -> {
-                            LOGGER.info("Streaming delete for non-existent document", DataMapHolder.getLogMap());
-                            filingHistoryService.callResourceChangedAbsentParent(companyNumber, transactionId);
+                            if (StringUtils.isNotBlank(request.parentEntityId())) {
+                                LOGGER.info(
+                                        "Child delete requested for document without parent - process will terminate and no stream event sent",
+                                        DataMapHolder.getLogMap());
+                            } else {
+                                LOGGER.info("Streaming delete for non-existent document", DataMapHolder.getLogMap());
+                                filingHistoryService.callResourceChangedAbsentParent(companyNumber, transactionId);
+                            }
                         });
     }
 

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/service/FilingHistoryDeleteProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/service/FilingHistoryDeleteProcessor.java
@@ -62,7 +62,7 @@ public class FilingHistoryDeleteProcessor implements DeleteProcessor {
                         () -> {
                             if (StringUtils.isNotBlank(request.parentEntityId())) {
                                 LOGGER.info(
-                                        "Child delete requested for document without parent - process will terminate and no stream event sent",
+                                        "Child delete for non existent document - stopping processing",
                                         DataMapHolder.getLogMap());
                             } else {
                                 LOGGER.info("Streaming delete for non-existent document", DataMapHolder.getLogMap());

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AnnotationTransactionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AnnotationTransactionIT.java
@@ -1231,6 +1231,7 @@ class AnnotationTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID)
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", CHILD_ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", ENTITY_ID)
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -1278,6 +1279,7 @@ class AnnotationTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID)
                 .header("X-DELTA-AT", STALE_REQUEST_DELTA_AT)
                 .header("X-ENTITY-ID", CHILD_ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", ENTITY_ID)
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -1334,6 +1336,7 @@ class AnnotationTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID)
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", EXISTING_CHILD_ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", ENTITY_ID)
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -1378,6 +1381,7 @@ class AnnotationTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID)
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", CHILD_ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", ENTITY_ID)
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -1422,6 +1426,7 @@ class AnnotationTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID)
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", "")
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AssociatedFilingTransactionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/AssociatedFilingTransactionIT.java
@@ -1039,6 +1039,7 @@ class AssociatedFilingTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID)
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", CHILD_ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", ENTITY_ID)
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -1082,6 +1083,7 @@ class AssociatedFilingTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID)
                 .header("X-DELTA-AT", STALE_REQUEST_DELTA_AT)
                 .header("X-ENTITY-ID", CHILD_ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", ENTITY_ID)
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -1141,6 +1143,7 @@ class AssociatedFilingTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID)
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", EXISTING_CHILD_ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", ENTITY_ID)
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -1186,6 +1189,7 @@ class AssociatedFilingTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID)
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", CHILD_ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", ENTITY_ID)
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerIT.java
@@ -10,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.http.HttpHeaders.LOCATION;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -827,6 +828,7 @@ class FilingHistoryControllerIT {
                 .header("X-Request-Id", "ABCD1234")
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", "")
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -865,6 +867,7 @@ class FilingHistoryControllerIT {
                 .header("X-Request-Id", "ABCD1234")
                 .header("X-DELTA-AT", STALE_REQUEST_DELTA_AT)
                 .header("X-ENTITY-ID", ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", "")
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -923,6 +926,7 @@ class FilingHistoryControllerIT {
                 .header("X-Request-Id", "ABCD1234")
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", "")
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -933,6 +937,32 @@ class FilingHistoryControllerIT {
 
         verify(instantSupplier).get();
         WireMock.verify(requestMadeFor(
+                new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResourceDeleteAbsentData())));
+    }
+
+    @Test
+    void shouldNotCallResourceChangeAndReturn200OkWhenDocumentDoesNotExistForChildDelete() throws Exception {
+        // given
+        assertNull(mongoTemplate.findById(TRANSACTION_ID, FilingHistoryDocument.class));
+
+        // when
+        final ResultActions result = mockMvc.perform(delete(DELETE_REQUEST_URI, COMPANY_NUMBER, TRANSACTION_ID)
+                .header("ERIC-Identity", "123")
+                .header("ERIC-Identity-Type", "key")
+                .header("ERIC-Authorised-Key-Privileges", "internal-app")
+                .header("X-Request-Id", "ABCD1234")
+                .header("X-DELTA-AT", DELTA_AT)
+                .header("X-ENTITY-ID", CHILD_ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", ENTITY_ID)
+                .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk());
+
+        assertNull(mongoTemplate.findById(TRANSACTION_ID, FilingHistoryDocument.class));
+
+        verifyNoInteractions(instantSupplier);
+        WireMock.verify(0, requestMadeFor(
                 new ResourceChangedRequestMatcher(RESOURCE_CHANGED_URI, getExpectedChangedResourceDeleteAbsentData())));
     }
 
@@ -960,6 +990,7 @@ class FilingHistoryControllerIT {
                 .header("X-Request-Id", "ABCD1234")
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", "missingChildEntityId")
+                .header("X-PARENT-ENTITY-ID", ENTITY_ID)
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -1247,6 +1278,7 @@ class FilingHistoryControllerIT {
                 .header("X-Request-Id", "ABCD1234")
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", "")
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -1285,6 +1317,7 @@ class FilingHistoryControllerIT {
                 .header("X-Request-Id", "ABCD1234")
                 .header("X-DELTA-AT", STALE_REQUEST_DELTA_AT)
                 .header("X-ENTITY-ID", ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", "")
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -1326,6 +1359,7 @@ class FilingHistoryControllerIT {
                 .header("X-Request-Id", "ABCD1234")
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", "")
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerTest.java
@@ -258,34 +258,6 @@ class FilingHistoryControllerTest {
         verify(deleteProcessor).processFilingHistoryDelete(request);
     }
 
-    @ParameterizedTest
-    @CsvSource(value = {
-            "parent_entity_id",
-            "null",
-            "''"
-    }, nullValues = "null")
-    void shouldReturn404WhenDeleteAndNotFoundException(final String parentEntityId) {
-        // given
-        doThrow(NotFoundException.class)
-                .when(deleteProcessor).processFilingHistoryDelete(any());
-
-        FilingHistoryDeleteRequest request = FilingHistoryDeleteRequest.builder()
-                .companyNumber(COMPANY_NUMBER)
-                .transactionId(TRANSACTION_ID)
-                .entityId(ENTITY_ID)
-                .deltaAt(DELTA_AT)
-                .parentEntityId(parentEntityId)
-                .build();
-
-        // when
-        Executable executable = () -> controller.deleteFilingHistoryTransaction(COMPANY_NUMBER,
-                TRANSACTION_ID, DELTA_AT, ENTITY_ID, parentEntityId);
-
-        // then
-        assertThrows(NotFoundException.class, executable);
-        verify(deleteProcessor).processFilingHistoryDelete(request);
-    }
-
     @Test
     void shouldReturn200OKWhenDocumentMetadataRequest() {
         // given

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerTest.java
@@ -12,6 +12,8 @@ import static org.springframework.http.HttpHeaders.LOCATION;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -38,8 +40,6 @@ class FilingHistoryControllerTest {
     private static final String ENTITY_ID = "entity_id";
     private static final String DELTA_AT = "20151025185208001000";
     private static final String COMPANY_NUMBER = "12345678";
-    private static final FilingHistoryDeleteRequest DELETE_REQUEST =
-            new FilingHistoryDeleteRequest(COMPANY_NUMBER, TRANSACTION_ID, ENTITY_ID, DELTA_AT);
     private static final int START_INDEX = 0;
     private static final int DEFAULT_ITEMS_PER_PAGE = 25;
 
@@ -51,8 +51,6 @@ class FilingHistoryControllerTest {
     private FilingHistoryGetResponseProcessor getResponseProcessor;
     @Mock
     private FilingHistoryDeleteProcessor deleteProcessor;
-    @Mock
-    private FilingHistoryDeleteRequest deleteRequest;
     @Mock
     private InternalFilingHistoryApi requestBody;
     @Mock
@@ -231,35 +229,61 @@ class FilingHistoryControllerTest {
         verify(upsertProcessor).processFilingHistory(TRANSACTION_ID, COMPANY_NUMBER, requestBody);
     }
 
-    @Test
-    void shouldReturn200WhenDeleteSingleTransaction() {
+    @ParameterizedTest
+    @CsvSource(value = {
+            "parent_entity_id",
+            "null",
+            "''"
+    }, nullValues = "null")
+    void shouldReturn200WhenDeleteSingleTransaction(final String parentEntityId) {
         // given
         final ResponseEntity<Void> expectedResponse = ResponseEntity
                 .status(HttpStatus.OK)
                 .build();
 
+        FilingHistoryDeleteRequest request = FilingHistoryDeleteRequest.builder()
+                .companyNumber(COMPANY_NUMBER)
+                .transactionId(TRANSACTION_ID)
+                .entityId(ENTITY_ID)
+                .deltaAt(DELTA_AT)
+                .parentEntityId(parentEntityId)
+                .build();
+
         // when
         final ResponseEntity<Void> actualResponse = controller.deleteFilingHistoryTransaction(COMPANY_NUMBER,
-                TRANSACTION_ID, DELTA_AT, ENTITY_ID);
+                TRANSACTION_ID, DELTA_AT, ENTITY_ID, parentEntityId);
 
         // then
         assertEquals(expectedResponse, actualResponse);
-        verify(deleteProcessor).processFilingHistoryDelete(DELETE_REQUEST);
+        verify(deleteProcessor).processFilingHistoryDelete(request);
     }
 
-    @Test
-    void shouldReturn404WhenDeleteAndNotFoundException() {
+    @ParameterizedTest
+    @CsvSource(value = {
+            "parent_entity_id",
+            "null",
+            "''"
+    }, nullValues = "null")
+    void shouldReturn404WhenDeleteAndNotFoundException(final String parentEntityId) {
         // given
         doThrow(NotFoundException.class)
                 .when(deleteProcessor).processFilingHistoryDelete(any());
 
+        FilingHistoryDeleteRequest request = FilingHistoryDeleteRequest.builder()
+                .companyNumber(COMPANY_NUMBER)
+                .transactionId(TRANSACTION_ID)
+                .entityId(ENTITY_ID)
+                .deltaAt(DELTA_AT)
+                .parentEntityId(parentEntityId)
+                .build();
+
         // when
         Executable executable = () -> controller.deleteFilingHistoryTransaction(COMPANY_NUMBER,
-                TRANSACTION_ID, DELTA_AT, ENTITY_ID);
+                TRANSACTION_ID, DELTA_AT, ENTITY_ID, parentEntityId);
 
         // then
         assertThrows(NotFoundException.class, executable);
-        verify(deleteProcessor).processFilingHistoryDelete(DELETE_REQUEST);
+        verify(deleteProcessor).processFilingHistoryDelete(request);
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/ResolutionTransactionIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/ResolutionTransactionIT.java
@@ -1166,6 +1166,7 @@ class ResolutionTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID)
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", CHILD_ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", "")
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -1207,6 +1208,7 @@ class ResolutionTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID)
                 .header("X-DELTA-AT", STALE_REQUEST_DELTA_AT)
                 .header("X-ENTITY-ID", CHILD_ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", "")
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -1248,6 +1250,7 @@ class ResolutionTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID)
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", "")
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -1313,6 +1316,7 @@ class ResolutionTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID)
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", CHILD_ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", ENTITY_ID)
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -1355,6 +1359,7 @@ class ResolutionTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID)
                 .header("X-DELTA-AT", STALE_REQUEST_DELTA_AT)
                 .header("X-ENTITY-ID", CHILD_ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", ENTITY_ID)
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -1411,6 +1416,7 @@ class ResolutionTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID)
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", EXISTING_CHILD_ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", ENTITY_ID)
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -1455,6 +1461,7 @@ class ResolutionTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID)
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", CHILD_ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", ENTITY_ID)
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then
@@ -1500,6 +1507,7 @@ class ResolutionTransactionIT {
                 .header("X-Request-Id", CONTEXT_ID)
                 .header("X-DELTA-AT", DELTA_AT)
                 .header("X-ENTITY-ID", ENTITY_ID)
+                .header("X-PARENT-ENTITY-ID", "")
                 .contentType(MediaType.APPLICATION_JSON));
 
         // then


### PR DESCRIPTION
* When a child delete request is received, previously a stream event would be sent out even if the mongo document had already been deleted. This is not desired behaviour. In the specific case where a child delete request comes through AND the parent has already been deleted (which is to say the whole doc has already been deleted from mongo), we want to cease processing and NOT send out a resource changed call.

## Describe the changes

### Related Jira tickets

[DSND-3241](https://companieshouse.atlassian.net/browse/DSND-3241)

## Developer check list

### General

- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on Tilt?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._


[DSND-3241]: https://companieshouse.atlassian.net/browse/DSND-3241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ