### PR TITLE
DSND-3241: Add default value to parent entity id

### DIFF
--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryController.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryController.java
@@ -106,7 +106,7 @@ public class FilingHistoryController {
             @PathVariable("transaction_id") final String transactionId,
             @RequestHeader("X-DELTA-AT") final String deltaAt,
             @RequestHeader("X-ENTITY-ID") final String entityId,
-            @RequestHeader("X-PARENT-ENTITY-ID") final String parentEntityId) {
+            @RequestHeader(value = "X-PARENT-ENTITY-ID", defaultValue = "") final String parentEntityId) {
 
         DataMapHolder.get()
                 .companyNumber(companyNumber)

--- a/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerIT.java
+++ b/src/test/java/uk/gov/companieshouse/filinghistory/api/controller/FilingHistoryControllerIT.java
@@ -31,8 +31,6 @@ import java.util.function.Supplier;
 import org.bson.Document;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
* Previously, if a parent entity id was not present on the delete request, it would throw a 400 bad request. Adding a default value means we can handle this now and set it to a blank string instead.

[DSND-3241](https://companieshouse.atlassian.net/browse/DSND-3241)

[DSND-3241]: https://companieshouse.atlassian.net/browse/DSND-3241?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ