### PR TITLE
ASM-527: Fix grpc-api vulnerabilities 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -76,6 +76,13 @@
         <artifactId>commons-lang3</artifactId>
         <version>3.18.0</version>
       </dependency>
+
+      <!-- Pinning version to address CVE-2024-11407, CVE-2024-7246 grpc-api pulled transitively-->
+      <dependency>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-api</artifactId>
+        <version>1.60.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
Updated grpc-api to version 1.60.2 to address: CVE-2024-11407 (CVSS 6.9) & CVE-2024-7246 (CVSS 6.3)

This transitive dependency is pulled via google-http-client from api-sdk-manager-java-library.

# Describe the changes

## Related Jira tickets

[ASM-527](https://companieshouse.atlassian.net/browse/ASM-527)

## Developer check list

### General

- [ ] Is the PR as small as it can be?
- [ ] Has the Jira ticket been updated with any relevant comments?
- [ ] Is the `README` up to date?
- [ ] Has the `POM` been updated for the latest versions of dependencies?
- [ ] Has the code been double-checked against `main`?
- [ ] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [ ] Has the code been tested locally and/or passed the API Karate tests on docker-chs-development?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [ ] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._


[ASM-527]: https://companieshouse.atlassian.net/browse/ASM-527?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ