### PR TITLE
ASM-1357 Bump up libraries for security and use commons-lang3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,11 +19,11 @@
   <properties>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <spring.boot.version>3.5.8</spring.boot.version>
-    <spring.security.version>6.5.7</spring.security.version>
+    <spring.boot.version>3.5.13</spring.boot.version>
+    <spring.security.version>6.5.9</spring.security.version>
     <jib-maven-plugin.version>3.4.4</jib-maven-plugin.version>
-    <structured-logging.version>3.0.24</structured-logging.version>
-    <api-sdk-manager-java-library.version>3.0.6</api-sdk-manager-java-library.version>
+    <structured-logging.version>3.0.52</structured-logging.version>
+    <api-sdk-manager-java-library.version>3.0.18</api-sdk-manager-java-library.version>
     <api-security-java.version>2.0.8</api-security-java.version>
     <private-api-sdk-java.version>4.0.258</private-api-sdk-java.version>
     <maven-surefire-plugin.version>3.5.2</maven-surefire-plugin.version>
@@ -56,33 +56,13 @@
         <scope>import</scope>
       </dependency>
 
-      <!-- Pinning version to address CVE-2025-48734 commons-beanutils pulled transitively-->
-      <dependency>
-        <groupId>commons-beanutils</groupId>
-        <artifactId>commons-beanutils</artifactId>
-        <version>1.11.0</version>
-      </dependency>
-
-      <!-- Pinning version to address CVE-2022-25647 gson pulled transitively-->
-      <dependency>
-        <groupId>com.google.code.gson</groupId>
-        <artifactId>gson</artifactId>
-        <version>2.12.1</version>
-      </dependency>
-
       <!-- Pinning version to address CVE-2025-48924 commons-lang3 pulled transitively-->
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
-        <version>3.18.0</version>
+        <version>3.20.0</version>
       </dependency>
 
-      <!-- Pinning version to address CVE-2024-7246 grpc-api pulled transitively -->
-      <dependency>
-        <groupId>io.grpc</groupId>
-        <artifactId>grpc-api</artifactId>
-        <version>1.60.2</version>
-      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/auth/AuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/auth/AuthenticationInterceptor.java
@@ -12,7 +12,7 @@ import jakarta.annotation.Nonnull;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Optional;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.http.HttpMethod;
 import org.springframework.lang.Nullable;

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/DateUtils.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/DateUtils.java
@@ -8,7 +8,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.util.Optional;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 public final class DateUtils {
 

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/ChildDeleteMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/delete/ChildDeleteMapper.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.filinghistory.api.FilingHistoryApplication;
 import uk.gov.companieshouse.filinghistory.api.exception.ConflictException;

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/AnnotationTransactionMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/AnnotationTransactionMapper.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.filinghistory.api.mapper.upsert;
 
 import java.time.Instant;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.filinghistory.InternalData;
 import uk.gov.companieshouse.api.filinghistory.InternalFilingHistoryApi;

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ChildListMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ChildListMapper.java
@@ -6,7 +6,7 @@ import static uk.gov.companieshouse.filinghistory.api.mapper.DateUtils.isDeltaSt
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import uk.gov.companieshouse.api.filinghistory.InternalFilingHistoryApi;
 import uk.gov.companieshouse.filinghistory.api.exception.ConflictException;
 import uk.gov.companieshouse.filinghistory.api.logging.DataMapHolder;

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ResolutionTransactionMapper.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/mapper/upsert/ResolutionTransactionMapper.java
@@ -3,7 +3,7 @@ package uk.gov.companieshouse.filinghistory.api.mapper.upsert;
 import static uk.gov.companieshouse.filinghistory.api.mapper.DateUtils.stringToInstant;
 
 import java.time.Instant;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.filinghistory.InternalData;
 import uk.gov.companieshouse.api.filinghistory.InternalFilingHistoryApi;

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/service/AnnotationPutRequestValidator.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/service/AnnotationPutRequestValidator.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.filinghistory.api.service;
 
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.filinghistory.Annotation;
 import uk.gov.companieshouse.api.filinghistory.ExternalData;

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/service/AssociatedFilingPutRequestValidator.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/service/AssociatedFilingPutRequestValidator.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.filinghistory.api.service;
 
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.filinghistory.AssociatedFiling;
 import uk.gov.companieshouse.api.filinghistory.ExternalData;

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/service/FilingHistoryDeleteProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/service/FilingHistoryDeleteProcessor.java
@@ -2,7 +2,7 @@ package uk.gov.companieshouse.filinghistory.api.service;
 
 import static uk.gov.companieshouse.filinghistory.api.mapper.DateUtils.isDeltaStale;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.filinghistory.api.FilingHistoryApplication;
 import uk.gov.companieshouse.filinghistory.api.exception.BadRequestException;

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/service/ResolutionPutRequestValidator.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/service/ResolutionPutRequestValidator.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.filinghistory.api.service;
 
 import java.util.List;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.filinghistory.ExternalData;
 import uk.gov.companieshouse.api.filinghistory.InternalData;

--- a/src/main/java/uk/gov/companieshouse/filinghistory/api/service/TopLevelPutRequestValidator.java
+++ b/src/main/java/uk/gov/companieshouse/filinghistory/api/service/TopLevelPutRequestValidator.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.filinghistory.api.service;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.filinghistory.ExternalData;
 import uk.gov.companieshouse.api.filinghistory.InternalData;


### PR DESCRIPTION
- Update libraries to address latest vulnerabilities identified by DependencyTrack
- Removed explicit dependencies no longer brought in by updated libraries
- Migrated instances of `StringUtils` from `commons-lang` to `commons-lang3` to remove vulnerable commons-lang dependency (`commons-lang v2.6`) ([CVE-2025-48924](https://dependency-track.companieshouse.gov.uk/vulnerabilities/NVD/CVE-2025-48924))

## Related Jira tickets

[ASM-1357](https://companieshouse.atlassian.net/browse/ASM-1357)

## Developer check list

### General

- [x] Is the PR as small as it can be?
- [x] Has the Jira ticket been updated with any relevant comments?
- [x] Is the `README` up to date?
- [x] Has the `POM` been updated for the latest versions of dependencies?
- [x] Has the code been double-checked against `main`?
- [x] Does the code adhere standards in this repository, including SonarQube checks?

### Testing

- [ ] Do the code changes have unit and integration tests with code coverage > 80%?
- [x] Has the code been tested locally and/or passed the API Karate tests on docker-chs-development?
- [ ] Have mandatory manual test cases been run?
- [ ] Are extra Karate tests required?
- [x] Are all the test data resources up to date?

### Release preparation

_Where possible, add links to the respective Jira tickets when an item is checked_

- [ ] Have these changes been included in a release ticket?
- [ ] Are changes required to the `docker-chs-development` deployment or test data?
- [ ] Are any changes required to the environment added to deployment repositories?

## Notes to the tester

_Add any testing hints or instructions here._


[ASM-1357]: https://companieshouse.atlassian.net/browse/ASM-1357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ